### PR TITLE
feat: Read fake data from file

### DIFF
--- a/cmd/stdcov-cli/WIP.md
+++ b/cmd/stdcov-cli/WIP.md
@@ -7,6 +7,13 @@
 Server:
 - Validate request with OapiRequestValidator middleware
 
+Possible assertions:
+- "All returned results MUST match the query parameters"
+- "the carpooling operator SHOULD return in priority the most relevant 
+  results. The measure of relevance is left to the discretion of the 
+  carpooling operator."
+- unique ids, same operator fields
+
 
 Vocabulary :
 

--- a/cmd/stdcov-cli/WIP.md
+++ b/cmd/stdcov-cli/WIP.md
@@ -16,6 +16,10 @@ Possible assertions driver journeys:
 - weburl required if deeplink supported.
 - long-lat in France ?
 
+Validation:
+- Validate response data from file on import ! 
+- Options : do not allow undocumented status code 
+  (options.IncludeResponseStatus)
 
 Vocabulary :
 

--- a/cmd/stdcov-cli/WIP.md
+++ b/cmd/stdcov-cli/WIP.md
@@ -7,12 +7,14 @@
 Server:
 - Validate request with OapiRequestValidator middleware
 
-Possible assertions:
+Possible assertions driver journeys:
 - "All returned results MUST match the query parameters"
 - "the carpooling operator SHOULD return in priority the most relevant 
   results. The measure of relevance is left to the discretion of the 
   carpooling operator."
-- unique ids, same operator fields
+- unique ids, same operator fields, operator fields format
+- weburl required if deeplink supported.
+- long-lat in France ?
 
 
 Vocabulary :

--- a/cmd/stdcov-cli/assertions.go
+++ b/cmd/stdcov-cli/assertions.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"gitlab.com/multi/stdcov-api-test/cmd/validate"
 )
 
 // An Assertion is a unit test that can be executed and that can describe
@@ -237,7 +238,7 @@ type assertDriverJourneysFormat struct {
 }
 
 func (a assertDriverJourneysFormat) Execute() error {
-	err := ValidateResponse(a.request, a.response)
+	err := validate.Response(a.request, a.response)
 	return err
 }
 

--- a/cmd/stdcov-service/api.go
+++ b/cmd/stdcov-service/api.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
@@ -45,9 +46,8 @@ func (*StdCovServerImpl) GetDriverJourneys(
 	ctx echo.Context,
 	params server.GetDriverJourneysParams,
 ) error {
-	defaultDataFile := "./data/defaultJourneyData.json"
-	v, _ := ReadJourneyDataFromFile(defaultDataFile)
-	return ctx.JSON(http.StatusOK, v)
+	fmt.Printf("%+v\n", DriverJourneysData)
+	return ctx.JSON(http.StatusOK, DriverJourneysData)
 }
 
 // GetDriverRegularTrips searches for matching regular driver trip.

--- a/cmd/stdcov-service/api.go
+++ b/cmd/stdcov-service/api.go
@@ -45,8 +45,9 @@ func (*StdCovServerImpl) GetDriverJourneys(
 	ctx echo.Context,
 	params server.GetDriverJourneysParams,
 ) error {
-	// Implement me
-	return ctx.JSON(http.StatusOK, []server.DriverJourney{})
+	defaultDataFile := "./data/defaultJourneyData.json"
+	v, _ := ReadJourneyDataFromFile(defaultDataFile)
+	return ctx.JSON(http.StatusOK, v)
 }
 
 // GetDriverRegularTrips searches for matching regular driver trip.

--- a/cmd/stdcov-service/data.go
+++ b/cmd/stdcov-service/data.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"encoding/json"
-	"errors"
 	"io"
 	"os"
 
 	"gitlab.com/multi/stdcov-api-test/cmd/stdcov-service/server"
 )
 
+// ReadJourneyDataFromFile reads a []DriverJourney array from a json file at given
+// path
 func ReadJourneyDataFromFile(path string) ([]server.DriverJourney, error) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -17,7 +18,8 @@ func ReadJourneyDataFromFile(path string) ([]server.DriverJourney, error) {
 	return ReadJourneyData(f)
 }
 
-// ReadJourneyData reads starting journey data from json file
+// ReadJourneyData reads journey data from io.Reader with json data
+// It does not validate data
 func ReadJourneyData(r io.Reader) ([]server.DriverJourney, error) {
 	var journeyData []server.DriverJourney
 	bytes, readErr := io.ReadAll(r)
@@ -26,24 +28,5 @@ func ReadJourneyData(r io.Reader) ([]server.DriverJourney, error) {
 	}
 
 	err := json.Unmarshal(bytes, &journeyData)
-	if journeyData == nil {
-		return nil, errors.New("no journey data to parse")
-	}
 	return journeyData, err
-}
-
-var journeys = []server.DriverJourney{
-	{
-		Driver: server.User{
-			Alias: "bob",
-			Id:    "1",
-		},
-		Operator:            "operator.example.org",
-		Duration:            3600,
-		PassengerDropLat:    48.8450234,
-		PassengerDropLng:    2.3997529,
-		PassengerPickupDate: 1665579951,
-		PassengerPickupLat:  47.461737,
-		Type:                server.DriverJourneyTypeDYNAMIC,
-	},
 }

--- a/cmd/stdcov-service/data.go
+++ b/cmd/stdcov-service/data.go
@@ -8,6 +8,8 @@ import (
 	"gitlab.com/multi/stdcov-api-test/cmd/stdcov-service/server"
 )
 
+// DriverJourneysData is the in-memory equivalent of the driver journeys
+// stored in a database
 var DriverJourneysData, _ = ReadJourneyDataFromFile("./data/defaultJourneyData.json")
 
 // ReadJourneyDataFromFile reads a []DriverJourney array from a json file at given

--- a/cmd/stdcov-service/data.go
+++ b/cmd/stdcov-service/data.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"encoding/json"
+	"errors"
 	"io"
 
 	"gitlab.com/multi/stdcov-api-test/cmd/stdcov-service/server"
@@ -8,8 +10,17 @@ import (
 
 // ReadJourneyData reads starting journey data from json file
 func ReadJourneyData(r io.Reader) ([]server.DriverJourney, error) {
+	var journeyData []server.DriverJourney
+	bytes, readErr := io.ReadAll(r)
+	if readErr != nil {
+		return nil, readErr
+	}
 
-	return []server.DriverJourney{{}}, nil
+	err := json.Unmarshal(bytes, &journeyData)
+	if journeyData == nil {
+		return nil, errors.New("no journey data to parse")
+	}
+	return journeyData, err
 }
 
 var journeys = []server.DriverJourney{

--- a/cmd/stdcov-service/data.go
+++ b/cmd/stdcov-service/data.go
@@ -4,9 +4,18 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"os"
 
 	"gitlab.com/multi/stdcov-api-test/cmd/stdcov-service/server"
 )
+
+func ReadJourneyDataFromFile(path string) ([]server.DriverJourney, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	return ReadJourneyData(f)
+}
 
 // ReadJourneyData reads starting journey data from json file
 func ReadJourneyData(r io.Reader) ([]server.DriverJourney, error) {

--- a/cmd/stdcov-service/data.go
+++ b/cmd/stdcov-service/data.go
@@ -9,7 +9,7 @@ import (
 // ReadJourneyData reads starting journey data from json file
 func ReadJourneyData(r io.Reader) ([]server.DriverJourney, error) {
 
-	return nil, nil
+	return []server.DriverJourney{{}}, nil
 }
 
 var journeys = []server.DriverJourney{

--- a/cmd/stdcov-service/data.go
+++ b/cmd/stdcov-service/data.go
@@ -1,0 +1,20 @@
+package main
+
+import "gitlab.com/multi/stdcov-api-test/cmd/stdcov-service/server"
+
+var journeys = []server.DriverJourney{
+	{
+		Driver: server.User{
+			// User's alias.
+			Alias: "bob",
+			Id:    "1",
+		},
+		Operator:            "operator.example.org",
+		Duration:            3600,
+		PassengerDropLat:    48.8450234,
+		PassengerDropLng:    2.3997529,
+		PassengerPickupDate: 1665579951,
+		PassengerPickupLat:  47.461737,
+		Type:                server.DriverJourneyTypeDYNAMIC,
+	},
+}

--- a/cmd/stdcov-service/data.go
+++ b/cmd/stdcov-service/data.go
@@ -1,26 +1,21 @@
 package main
 
 import (
+	"bytes"
+	_ "embed"
 	"encoding/json"
 	"io"
-	"os"
 
 	"gitlab.com/multi/stdcov-api-test/cmd/stdcov-service/server"
 )
 
+// DriverJourneyJSON stores default driver journey json data
+//go:embed data/defaultJourneyData.json
+var DriverJourneyJSON []byte
+
 // DriverJourneysData is the in-memory equivalent of the driver journeys
 // stored in a database
-var DriverJourneysData, _ = ReadJourneyDataFromFile("./data/defaultJourneyData.json")
-
-// ReadJourneyDataFromFile reads a []DriverJourney array from a json file at given
-// path
-func ReadJourneyDataFromFile(path string) ([]server.DriverJourney, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, err
-	}
-	return ReadJourneyData(f)
-}
+var DriverJourneysData, _ = ReadJourneyData(bytes.NewReader(DriverJourneyJSON))
 
 // ReadJourneyData reads journey data from io.Reader with json data
 // It does not validate data

--- a/cmd/stdcov-service/data.go
+++ b/cmd/stdcov-service/data.go
@@ -10,6 +10,7 @@ import (
 )
 
 // DriverJourneyJSON stores default driver journey json data
+//
 //go:embed data/defaultJourneyData.json
 var DriverJourneyJSON []byte
 

--- a/cmd/stdcov-service/data.go
+++ b/cmd/stdcov-service/data.go
@@ -1,11 +1,20 @@
 package main
 
-import "gitlab.com/multi/stdcov-api-test/cmd/stdcov-service/server"
+import (
+	"io"
+
+	"gitlab.com/multi/stdcov-api-test/cmd/stdcov-service/server"
+)
+
+// ReadJourneyData reads starting journey data from json file
+func ReadJourneyData(r io.Reader) ([]server.DriverJourney, error) {
+
+	return nil, nil
+}
 
 var journeys = []server.DriverJourney{
 	{
 		Driver: server.User{
-			// User's alias.
 			Alias: "bob",
 			Id:    "1",
 		},

--- a/cmd/stdcov-service/data.go
+++ b/cmd/stdcov-service/data.go
@@ -8,6 +8,8 @@ import (
 	"gitlab.com/multi/stdcov-api-test/cmd/stdcov-service/server"
 )
 
+var DriverJourneysData, _ = ReadJourneyDataFromFile("./data/defaultJourneyData.json")
+
 // ReadJourneyDataFromFile reads a []DriverJourney array from a json file at given
 // path
 func ReadJourneyDataFromFile(path string) ([]server.DriverJourney, error) {

--- a/cmd/stdcov-service/data/defaultJourneyData.json
+++ b/cmd/stdcov-service/data/defaultJourneyData.json
@@ -4,7 +4,20 @@
 			"alias": "bob",
         "id":    "1"
       },
-		"ieurs":            "operator.example.org",
+		"operator":            "operator.example.org",
+		"duration":            3600,
+		"passengerDropLat":    48.8450234,
+		"passengerDropLng":    2.3997529,
+		"passengerPickupDate": 1665579951,
+		"passengerPickupLat":  47.461737,
+		"type": "DYNAMIC"
+	},
+	{
+		"driver": {
+			"alias": "bob",
+        "id":    "1"
+      },
+		"operator":            "operator.example.org",
 		"duration":            3600,
 		"passengerDropLat":    48.8450234,
 		"passengerDropLng":    2.3997529,

--- a/cmd/stdcov-service/data/defaultJourneyData.json
+++ b/cmd/stdcov-service/data/defaultJourneyData.json
@@ -1,0 +1,15 @@
+[
+	{
+		"driver": {
+			"alias": "bob",
+        "id":    "1"
+      },
+		"ieurs":            "operator.example.org",
+		"duration":            3600,
+		"passengerDropLat":    48.8450234,
+		"passengerDropLng":    2.3997529,
+		"passengerPickupDate": 1665579951,
+		"passengerPickupLat":  47.461737,
+		"type": "DYNAMIC"
+	}
+]

--- a/cmd/stdcov-service/data_test.go
+++ b/cmd/stdcov-service/data_test.go
@@ -1,57 +1,15 @@
 package main
 
 import (
-	"strings"
+	"fmt"
 	"testing"
-
-	"github.com/google/go-cmp/cmp"
-	"gitlab.com/multi/stdcov-api-test/cmd/stdcov-service/server"
 )
 
-func TestReadJourneyData(t *testing.T) {
-	expected := []server.DriverJourney{
-		{
-			Driver: server.User{
-				Alias: "bob",
-				Id:    "1",
-			},
-			Operator:            "operator.example.org",
-			Duration:            3600,
-			PassengerDropLat:    48.8450234,
-			PassengerDropLng:    2.3997529,
-			PassengerPickupDate: 1665579951,
-			PassengerPickupLat:  47.461737,
-			Type:                server.DriverJourneyTypeDYNAMIC,
-		},
-	}
-
-	jsonDriverJourney := `[
-	{
-		"driver": {
-			"alias": "bob",
-			"id":    "1"
-		},
-		"operator":            "operator.example.org",
-		"duration":            3600,
-		"passengerDropLat":    48.8450234,
-		"passengerDropLng":    2.3997529,
-		"passengerPickupDate": 1665579951,
-		"passengerPickupLat":  47.461737,
-		"type": "DYNAMIC"
-	}
-]`
-	r := strings.NewReader(jsonDriverJourney)
-	got, err := ReadJourneyData(r)
-
+func TestDefaultJourneyData(t *testing.T) {
+	defaultDataFile := "./data/defaultJourneyData.json"
+	v, err := ReadJourneyDataFromFile(defaultDataFile)
+	fmt.Printf("%+v\n", v)
 	if err != nil {
-		t.Error("Error while reading test string")
-	}
-	if len(got) != len(expected) {
-		t.Logf("Expected length of data: %d", len(expected))
-		t.Logf("Got length of data: %d", len(got))
-		t.Error()
-	}
-	if !cmp.Equal(got, expected) {
-		t.Error("Parsing journey data does not produce expected output")
+		t.Error(err)
 	}
 }

--- a/cmd/stdcov-service/data_test.go
+++ b/cmd/stdcov-service/data_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"gitlab.com/multi/stdcov-api-test/cmd/stdcov-service/server"
 )
 
@@ -49,5 +50,8 @@ func TestReadJourneyData(t *testing.T) {
 		t.Logf("Expected length of data: %d", len(expected))
 		t.Logf("Got length of data: %d", len(got))
 		t.Error()
+	}
+	if !cmp.Equal(got, expected) {
+		t.Error("Parsing journey data does not produce expected output")
 	}
 }

--- a/cmd/stdcov-service/data_test.go
+++ b/cmd/stdcov-service/data_test.go
@@ -1,12 +1,12 @@
 package main
 
 import (
+	"bytes"
 	"testing"
 )
 
 func TestDefaultJourneyData(t *testing.T) {
-	defaultDataFile := "./data/defaultJourneyData.json"
-	_, err := ReadJourneyDataFromFile(defaultDataFile)
+	_, err := ReadJourneyData(bytes.NewReader(DriverJourneyJSON))
 	if err != nil {
 		t.Error(err)
 	}

--- a/cmd/stdcov-service/data_test.go
+++ b/cmd/stdcov-service/data_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"gitlab.com/multi/stdcov-api-test/cmd/stdcov-service/server"
+)
+
+func TestReadJourneyData(t *testing.T) {
+	expected := []server.DriverJourney{
+		{
+			Driver: server.User{
+				Alias: "bob",
+				Id:    "1",
+			},
+			Operator:            "operator.example.org",
+			Duration:            3600,
+			PassengerDropLat:    48.8450234,
+			PassengerDropLng:    2.3997529,
+			PassengerPickupDate: 1665579951,
+			PassengerPickupLat:  47.461737,
+			Type:                server.DriverJourneyTypeDYNAMIC,
+		},
+	}
+
+	jsonDriverJourney := `[
+	{
+		"driver": {
+			"alias": "bob",
+			"id":    "1"
+		},
+		"operator":            "operator.example.org",
+		"duration":            3600,
+		"passengerDropLat":    48.8450234,
+		"passengerDropLng":    2.3997529,
+		"passengerPickupDate": 1665579951,
+		"passengerPickupLat":  47.461737,
+		"type": "DYNAMIC"
+	}
+]`
+	r := strings.NewReader(jsonDriverJourney)
+	got, err := ReadJourneyData(r)
+
+	if err != nil {
+		t.Error("Error while reading test string")
+	}
+	if len(got) != len(expected) {
+		t.Logf("Expected length of data: %d", len(expected))
+		t.Logf("Got length of data: %d", len(got))
+		t.Error()
+	}
+}

--- a/cmd/stdcov-service/data_test.go
+++ b/cmd/stdcov-service/data_test.go
@@ -1,14 +1,12 @@
 package main
 
 import (
-	"fmt"
 	"testing"
 )
 
 func TestDefaultJourneyData(t *testing.T) {
 	defaultDataFile := "./data/defaultJourneyData.json"
-	v, err := ReadJourneyDataFromFile(defaultDataFile)
-	fmt.Printf("%+v\n", v)
+	_, err := ReadJourneyDataFromFile(defaultDataFile)
 	if err != nil {
 		t.Error(err)
 	}

--- a/cmd/validate/validate_format.go
+++ b/cmd/validate/validate_format.go
@@ -1,8 +1,7 @@
-package main
+package validate
 
 import (
 	"context"
-	_ "embed"
 	"io"
 	"net/http"
 
@@ -13,18 +12,24 @@ import (
 	"gitlab.com/multi/stdcov-api-test/spec"
 )
 
-// ValidateResponse validates a Response against the openapi specification.
-func ValidateResponse(request *http.Request, response *http.Response) error {
+// Response validates a Response against the openapi specification.
+func Response(request *http.Request, response *http.Response) error {
 	ctx := context.Background()
 	loader := &openapi3.Loader{Context: ctx, IsExternalRefsAllowed: true}
 	doc, loadingErr := loader.LoadFromData(spec.OpenAPISpec)
-	panicIf(loadingErr) // Error only if problem with module internals
+	if loadingErr != nil {
+		panic(loadingErr) // Error only if problem with module internals
+	}
 
 	specValidationErr := doc.Validate(ctx)
-	panicIf(specValidationErr) // Error only if problem with module internals
+	if specValidationErr != nil {
+		panic(specValidationErr) // Error only if problem with module internals
+	}
 
 	router, routerErr := gorillamux.NewRouter(doc)
-	panicIf(routerErr) // Error only if problem with module internals
+	if routerErr != nil {
+		panic(routerErr) // Error only if problem with module internals
+	}
 
 	// Find route
 	route, pathParams, err := router.FindRoute(request)


### PR DESCRIPTION
Adds functionnality for reading fake DriverJourneys data from a json file. 

With default data in dir `cmd/stdcov_service/data`. 