### PR TITLE
New print

### DIFF
--- a/cmd/service/api_test.go
+++ b/cmd/service/api_test.go
@@ -196,11 +196,10 @@ func testGetDriverJourneyRequestWithData(
 		t.Fail()
 	}
 	response := rec.Result()
-	a := test.NewAssertionAccu()
 	flags := test.Flags{DisallowEmpty: !expectEmpty}
-	test.TestGetDriverJourneysResponse(testRequest, response, a, flags)
-	assert.Greater(t, len(a.GetAssertionResults()), 0)
-	for _, ar := range a.GetAssertionResults() {
+	assertionResults := test.TestGetDriverJourneysResponse(testRequest, response, flags)
+	assert.Greater(t, len(assertionResults), 0)
+	for _, ar := range assertionResults {
 		if err := ar.Unwrap(); err != nil {
 			t.Log(err)
 			t.Fail()

--- a/cmd/test/api_mapping.go
+++ b/cmd/test/api_mapping.go
@@ -29,19 +29,19 @@ var apiMapping = map[Endpoint][]RequestTestFun{
 	GetDriverJourneyEndpoint: {wrapTestResponseFun(TestGetDriverJourneysResponse)},
 }
 
-// SelectTestFuns returns the test functions related to a given request
-func SelectTestFuns(request *http.Request, server string) ([]RequestTestFun, error) {
+// SelectTestFuns returns the test functions related to a given request.
+func SelectTestFuns(request *http.Request, server string) (Endpoint, []RequestTestFun, error) {
 	endpoint, err := ExtractEndpoint(request, server)
 	if err != nil {
-		return nil, err
+		return Endpoint{}, nil, err
 	}
 	testFuns, ok := apiMapping[*endpoint]
 	if !ok {
-		return nil, fmt.Errorf("request to an unknown endpoint. Method: %s, path: %s",
+		return Endpoint{}, nil, fmt.Errorf("request to an unknown endpoint. Method: %s, path: %s",
 			request.Method,
 			request.URL.Path)
 	}
-	return testFuns, nil
+	return *endpoint, testFuns, nil
 }
 
 // ExtractEndpoint extracts the endpoint from a request, given server

--- a/cmd/test/api_mapping.go
+++ b/cmd/test/api_mapping.go
@@ -30,31 +30,27 @@ var apiMapping = map[Endpoint][]RequestTestFun{
 }
 
 // SelectTestFuns returns the test functions related to a given request.
-func SelectTestFuns(request *http.Request, server string) (Endpoint, []RequestTestFun, error) {
-	endpoint, err := ExtractEndpoint(request, server)
-	if err != nil {
-		return Endpoint{}, nil, err
-	}
-	testFuns, ok := apiMapping[*endpoint]
+func SelectTestFuns(request *http.Request, endpoint Endpoint) ([]RequestTestFun, error) {
+	testFuns, ok := apiMapping[endpoint]
 	if !ok {
-		return Endpoint{}, nil, fmt.Errorf("request to an unknown endpoint. Method: %s, path: %s",
+		return nil, fmt.Errorf("request to an unknown endpoint. Method: %s, path: %s",
 			request.Method,
 			request.URL.Path)
 	}
-	return *endpoint, testFuns, nil
+	return testFuns, nil
 }
 
 // ExtractEndpoint extracts the endpoint from a request, given server
 // information
-func ExtractEndpoint(request *http.Request, server string) (*Endpoint, error) {
+func ExtractEndpoint(request *http.Request, server string) (Endpoint, error) {
 	serverURL, err := url.Parse(server)
 	if err != nil {
-		return nil, err
+		return Endpoint{}, err
 	}
 	method := request.Method
 	path := strings.TrimPrefix(request.URL.Path, serverURL.Path)
 	if !strings.HasPrefix(path, "/") {
 		path = "/" + path
 	}
-	return &Endpoint{method, path}, nil
+	return Endpoint{method, path}, nil
 }

--- a/cmd/test/api_mapping.go
+++ b/cmd/test/api_mapping.go
@@ -24,13 +24,13 @@ var GetStatusEndpoint = Endpoint{http.MethodGet, "/status"}
 // GetDriverJourneyEndpoint is the Endpoint of GET /driver_journeys
 var GetDriverJourneyEndpoint = Endpoint{http.MethodGet, "/driver_journeys"}
 
-var apiMapping = map[Endpoint][]RequestTestFun{
-	GetStatusEndpoint:        {wrapTestResponseFun(TestGetStatusResponse)},
-	GetDriverJourneyEndpoint: {wrapTestResponseFun(TestGetDriverJourneysResponse)},
+var apiMapping = map[Endpoint][]ResponseTestFun{
+	GetStatusEndpoint:        {TestGetStatusResponse},
+	GetDriverJourneyEndpoint: {TestGetDriverJourneysResponse},
 }
 
 // SelectTestFuns returns the test functions related to a given request.
-func SelectTestFuns(endpoint Endpoint) ([]RequestTestFun, error) {
+func SelectTestFuns(endpoint Endpoint) ([]ResponseTestFun, error) {
 	testFuns, ok := apiMapping[endpoint]
 	if !ok {
 		return nil, fmt.Errorf("request to an unknown endpoint: %s", endpoint)

--- a/cmd/test/api_mapping.go
+++ b/cmd/test/api_mapping.go
@@ -25,8 +25,8 @@ var GetStatusEndpoint = Endpoint{http.MethodGet, "/status"}
 var GetDriverJourneyEndpoint = Endpoint{http.MethodGet, "/driver_journeys"}
 
 var apiMapping = map[Endpoint][]RequestTestFun{
-	GetStatusEndpoint:        {wrapTestResponseFun(TestGetStatusResponse, GetStatusEndpoint)},
-	GetDriverJourneyEndpoint: {wrapTestResponseFun(TestGetDriverJourneysResponse, GetDriverJourneyEndpoint)},
+	GetStatusEndpoint:        {wrapTestResponseFun(TestGetStatusResponse)},
+	GetDriverJourneyEndpoint: {wrapTestResponseFun(TestGetDriverJourneysResponse)},
 }
 
 // SelectTestFuns returns the test functions related to a given request

--- a/cmd/test/api_mapping.go
+++ b/cmd/test/api_mapping.go
@@ -30,12 +30,10 @@ var apiMapping = map[Endpoint][]RequestTestFun{
 }
 
 // SelectTestFuns returns the test functions related to a given request.
-func SelectTestFuns(request *http.Request, endpoint Endpoint) ([]RequestTestFun, error) {
+func SelectTestFuns(endpoint Endpoint) ([]RequestTestFun, error) {
 	testFuns, ok := apiMapping[endpoint]
 	if !ok {
-		return nil, fmt.Errorf("request to an unknown endpoint. Method: %s, path: %s",
-			request.Method,
-			request.URL.Path)
+		return nil, fmt.Errorf("request to an unknown endpoint: %s", endpoint)
 	}
 	return testFuns, nil
 }

--- a/cmd/test/assertions.go
+++ b/cmd/test/assertions.go
@@ -27,18 +27,14 @@ type AssertionResult struct {
 	// Error, if any
 	err error
 
-	// Endpoint under test
-	endpoint Endpoint
-
 	// A string that summarizes the assertion
 	assertionDescription string
 }
 
 // NewAssertionResult initializes an AssertionResult
-func NewAssertionResult(err error, endpointPath, endpointMethod, summary string) AssertionResult {
+func NewAssertionResult(err error, summary string) AssertionResult {
 	return AssertionResult{
 		err,
-		Endpoint{endpointMethod, endpointPath},
 		summary,
 	}
 }
@@ -64,7 +60,7 @@ func (ar AssertionResult) String() string {
 	resStr := fmt.Sprintf(
 		"%7s %-35s  %-35s",
 		symbol,
-		ar.endpoint,
+		"",
 		ar.assertionDescription,
 	)
 	if err != nil {
@@ -129,8 +125,7 @@ func (a *DefaultAssertionAccu) ExecuteAll() {
 
 		a.storedAssertionResults = append(
 			a.storedAssertionResults,
-			NewAssertionResult(err, a.endpoint.Path, a.endpoint.Method,
-				assertion.Describe()),
+			NewAssertionResult(err, assertion.Describe()),
 		)
 		_, critic := assertion.(CriticAssertion)
 		fatal := (critic && err != nil)

--- a/cmd/test/assertions.go
+++ b/cmd/test/assertions.go
@@ -44,31 +44,6 @@ func (ar AssertionResult) Unwrap() error {
 	return ar.err
 }
 
-// String implements Stringer interface.
-// Formats the AssertionResult nicely in one line (no linebreak).
-func (ar AssertionResult) String() string {
-
-	err := ar.Unwrap()
-
-	var symbol string
-	if err != nil {
-		symbol = "ERROR ❌"
-	} else {
-		symbol = "OK ✅"
-	}
-
-	resStr := fmt.Sprintf(
-		"%7s %-35s  %-35s",
-		symbol,
-		"",
-		ar.assertionDescription,
-	)
-	if err != nil {
-		resStr += fmt.Sprintf("\n%5s %s", "", err)
-	}
-	return resStr
-}
-
 /////////////////////////////////////////////////////////////
 
 // A CriticAssertion is an Assertion, which success is critic for the

--- a/cmd/test/assertions_test.go
+++ b/cmd/test/assertions_test.go
@@ -11,50 +11,6 @@ import (
 	"gitlab.com/multi/stdcov-api-test/cmd/util"
 )
 
-func TestAssertionResult_String(t *testing.T) {
-	endpointPath := "/endpoint_path"
-	endpointMethod := http.MethodGet
-	assertStr := "test assertion"
-	errorDescription := "Error description"
-
-	makeAssertionResult := func(err error) AssertionResult {
-		return NewAssertionResult(err, endpointPath, endpointMethod, assertStr)
-	}
-	shouldContain := func(t *testing.T, a AssertionResult, str string) {
-		t.Helper()
-		if !strings.Contains(a.String(), str) {
-			t.Logf("Assertion string : %s", a.String())
-			t.Error("Assertion string does not contain " + str)
-		}
-	}
-
-	testCases := []struct {
-		name string
-		err  error
-	}{
-		{
-			"Assertion without error",
-			nil,
-		},
-		{
-			"Assertion with error",
-			errors.New(errorDescription),
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run("Assertion with error", func(t *testing.T) {
-			a := makeAssertionResult(tc.err)
-			shouldContain(t, a, endpointMethod)
-			shouldContain(t, a, endpointPath)
-			shouldContain(t, a, assertStr)
-			if tc.err != nil {
-				shouldContain(t, a, errorDescription)
-			}
-		})
-	}
-}
-
 func TestExpectStatusCode(t *testing.T) {
 	testCases := []struct {
 		response         *http.Response

--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -27,7 +27,7 @@ func Run(server, URL string, verbose bool, query Query) int {
 	flags := Flags{
 		DisallowEmpty: false,
 	}
-	report, err := ExecuteTestSuite(c, req, flags)
+	report, err := TestRequest(c, req, flags)
 	if err != nil {
 		fmt.Println(err)
 		return 1

--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -27,7 +27,7 @@ func Run(server, URL string, verbose bool, query Query) int {
 	flags := Flags{
 		DisallowEmpty: false,
 	}
-	report, err := TestRequest(c, req, flags)
+	report, err := Request(c, req, flags)
 	if err != nil {
 		fmt.Println(err)
 		return 1

--- a/cmd/test/print.go
+++ b/cmd/test/print.go
@@ -1,0 +1,23 @@
+package test
+
+import "fmt"
+
+func printError(msg string) {
+	printWithSymbol("ERROR ❌", msg)
+}
+
+func printOK(msg string) {
+	printWithSymbol("OK ✅", msg)
+}
+
+func printDetail(msg string) {
+	printWithSymbol("", msg)
+}
+
+func printWithSymbol(symbol, msg string) {
+	fmt.Printf(
+		"%7s %s",
+		symbol,
+		msg,
+	)
+}

--- a/cmd/test/print.go
+++ b/cmd/test/print.go
@@ -2,21 +2,21 @@ package test
 
 import "fmt"
 
-func printError(msg string) {
-	printWithSymbol("ERROR ❌", msg)
+func stringError(msg string) string {
+	return stringWithSymbol("ERROR ❌", msg)
 }
 
-func printOK(msg string) {
-	printWithSymbol("OK ✅", msg)
+func stringOK(msg string) string {
+	return stringWithSymbol("OK ✅", msg)
 }
 
-func printDetail(msg string) {
-	printWithSymbol("", msg)
+func stringDetail(msg string) string {
+	return stringWithSymbol("", msg)
 }
 
-func printWithSymbol(symbol, msg string) {
-	fmt.Printf(
-		"%7s %s",
+func stringWithSymbol(symbol, msg string) string {
+	return fmt.Sprintf(
+		"%7s %s\n",
 		symbol,
 		msg,
 	)

--- a/cmd/test/report.go
+++ b/cmd/test/report.go
@@ -4,21 +4,31 @@ import "fmt"
 
 // Report stores assertionResults.
 type Report struct {
-	verbose             bool
-	allAssertionResults []AssertionResult
+	verbose          bool
+	endpoint         Endpoint
+	assertionResults []AssertionResult
+}
+
+func NewReport(assertionResults ...AssertionResult) Report {
+	return Report{assertionResults: assertionResults}
 }
 
 func (report *Report) String() string {
 	str := ""
-	for _, ar := range report.allAssertionResults {
-		str += toString(ar, report.verbose)
+	for _, ar := range report.assertionResults {
+		if ar.Unwrap() == nil && report.verbose {
+			str += stringOK(format(report.endpoint, ar.assertionDescription))
+		} else if err := ar.Unwrap(); err != nil {
+			str += stringError(format(report.endpoint, ar.assertionDescription))
+			str += stringDetail(err.Error())
+		}
 	}
 	return str
 }
 
 func (report *Report) countErrors() int {
 	nErr := 0
-	for _, ar := range report.allAssertionResults {
+	for _, ar := range report.assertionResults {
 		if ar.Unwrap() != nil {
 			nErr++
 		}
@@ -26,21 +36,11 @@ func (report *Report) countErrors() int {
 	return nErr
 }
 
+func format(endpoint Endpoint, assertionDescription string) string {
+	return fmt.Sprintf("%-35s %-35s", endpoint, assertionDescription)
+
+}
+
 func (report *Report) hasErrors() bool {
 	return report.countErrors() > 0
-}
-
-func toString(ar AssertionResult, verbose bool) string {
-	if shouldReport(ar, verbose) {
-		return fmt.Sprintf("%s\n", ar.String())
-	}
-	return ""
-
-}
-
-func shouldReport(ar AssertionResult, verbose bool) bool {
-	if ar.Unwrap() != nil || verbose {
-		return true
-	}
-	return false
 }

--- a/cmd/test/report.go
+++ b/cmd/test/report.go
@@ -9,6 +9,7 @@ type Report struct {
 	assertionResults []AssertionResult
 }
 
+// NewReport creates a new report with given assertion results
 func NewReport(assertionResults ...AssertionResult) Report {
 	return Report{assertionResults: assertionResults}
 }

--- a/cmd/test/test_suite.go
+++ b/cmd/test/test_suite.go
@@ -15,7 +15,7 @@ func TestRequest(client APIClient, request *http.Request, flags Flags) (*Report,
 	if err != nil {
 		return nil, err
 	}
-	selectedTestFuns, err := SelectTestFuns(request, endpoint)
+	selectedTestFuns, err := SelectTestFuns(endpoint)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/test/test_suite.go
+++ b/cmd/test/test_suite.go
@@ -9,8 +9,8 @@ import (
 // APIClient is a client to the API standard covoiturage
 type APIClient = *api.Client
 
-// TestRequest tests a request
-func TestRequest(client APIClient, request *http.Request, flags Flags) (*Report, error) {
+// Request tests a request
+func Request(client APIClient, request *http.Request, flags Flags) (*Report, error) {
 	endpoint, err := ExtractEndpoint(request, client.Server)
 	if err != nil {
 		return nil, err

--- a/cmd/test/test_suite.go
+++ b/cmd/test/test_suite.go
@@ -11,7 +11,11 @@ type APIClient = *api.Client
 
 // TestRequest tests a request
 func TestRequest(client APIClient, request *http.Request, flags Flags) (*Report, error) {
-	endpoint, selectedTestFuns, err := SelectTestFuns(request, client.Server)
+	endpoint, err := ExtractEndpoint(request, client.Server)
+	if err != nil {
+		return nil, err
+	}
+	selectedTestFuns, err := SelectTestFuns(request, endpoint)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/test/test_suite.go
+++ b/cmd/test/test_suite.go
@@ -34,7 +34,8 @@ func executeTestFuns(
 	for _, testFun := range tests {
 		all = append(all, wrapTestResponseFun(testFun)(client, request, flags)...)
 	}
-	return &Report{assertionResults: all}
+	report := NewReport(all...)
+	return &report
 }
 
 /////////////////////////////////////////////////////////////

--- a/cmd/test/test_suite.go
+++ b/cmd/test/test_suite.go
@@ -9,8 +9,8 @@ import (
 // APIClient is a client to the API standard covoiturage
 type APIClient = *api.Client
 
-// ExecuteTestSuite tests a client against all implemented tests
-func ExecuteTestSuite(client APIClient, request *http.Request, flags Flags) (*Report, error) {
+// TestRequest tests a request
+func TestRequest(client APIClient, request *http.Request, flags Flags) (*Report, error) {
 	selectedTestFuns, err := SelectTestFuns(request, client.Server)
 	if err != nil {
 		return nil, err
@@ -28,7 +28,7 @@ func executeTestFuns(
 	for _, testFun := range tests {
 		all = append(all, testFun(client, request, flags)...)
 	}
-	return &Report{allAssertionResults: all}
+	return &Report{assertionResults: all}
 }
 
 /////////////////////////////////////////////////////////////
@@ -38,10 +38,9 @@ func executeTestFuns(
 type RequestTestFun func(APIClient, *http.Request, Flags) []AssertionResult
 
 // wrapTestResponseFun wraps an TestResponseFun to a TestRequestFun
-func wrapTestResponseFun(f ResponseTestFun, endpoint Endpoint) RequestTestFun {
+func wrapTestResponseFun(f ResponseTestFun) RequestTestFun {
 	return func(c APIClient, request *http.Request, flags Flags) []AssertionResult {
 		a := NewAssertionAccu()
-		a.endpoint = endpoint
 		response, clientErr := c.Client.Do(request)
 		if clientErr != nil {
 			a.Queue(assertAPICallSuccess{clientErr})

--- a/cmd/test/test_suite.go
+++ b/cmd/test/test_suite.go
@@ -11,11 +11,13 @@ type APIClient = *api.Client
 
 // TestRequest tests a request
 func TestRequest(client APIClient, request *http.Request, flags Flags) (*Report, error) {
-	selectedTestFuns, err := SelectTestFuns(request, client.Server)
+	endpoint, selectedTestFuns, err := SelectTestFuns(request, client.Server)
 	if err != nil {
 		return nil, err
 	}
-	return executeTestFuns(client, request, selectedTestFuns, flags), nil
+	report := executeTestFuns(client, request, selectedTestFuns, flags)
+	report.endpoint = endpoint
+	return report, nil
 }
 
 func executeTestFuns(

--- a/cmd/test/test_suite_test.go
+++ b/cmd/test/test_suite_test.go
@@ -92,24 +92,6 @@ func cmpRequests(t *testing.T, req1, req2 *http.Request) bool {
 		bodyString[0] == bodyString[1]
 }
 
-/* func TestExecutedTestsGivenRequest(t *testing.T) { */
-/* 	path := "/driver_journeys" */
-/* 	method := http.MethodGet */
-/* 	r, err := http.NewRequest(method, path, strings.NewReader("")) */
-/* 	panicIf(err) */
-
-/* 	m := NewMockClientWithResponse(mockOKStatusResponse()) */
-/* 	report, err := TestRequest(m, r, defaultTestFlags) */
-/* 	panicIf(err) */
-/* 	for _, a := range report.assertionResults { */
-/* 		if a.endpoint.Path != path || a.endpoint.Method != method { */
-/* 			t.Logf("Path expected by request: %s %s", method, path) */
-/* 			t.Logf("Assertion run for: %s %s", a.endpoint.Method, a.endpoint.Path) */
-/* 			t.Error("Unexpected assertion run for given request") */
-/* 		} */
-/* 	} */
-/* } */
-
 func TestNoEmpty(t *testing.T) {
 	a := NewAssertionAccu()
 	testGetDriverJourneys(nil, mockOKStatusResponse(), a, Flags{DisallowEmpty: true})

--- a/cmd/test/test_suite_test.go
+++ b/cmd/test/test_suite_test.go
@@ -58,7 +58,7 @@ func TestRequests(t *testing.T) {
 				AssertionAccumulator, Flags) []AssertionResult {
 				return nil
 			}
-			wrapTestResponseFun(testNoAssertions, Endpoint{})(m, r, defaultTestFlags)
+			wrapTestResponseFun(testNoAssertions)(m, r, defaultTestFlags)
 
 			requestsDone := m.Client.(*MockClient).Requests
 			if len(requestsDone) != 1 {
@@ -94,23 +94,23 @@ func cmpRequests(t *testing.T, req1, req2 *http.Request) bool {
 		bodyString[0] == bodyString[1]
 }
 
-func TestExecutedTestsGivenRequest(t *testing.T) {
-	m := NewMockClientWithResponse(mockOKStatusResponse())
-	path := "/driver_journeys"
-	method := http.MethodGet
-	r, err := http.NewRequest(method, path, strings.NewReader(""))
-	panicIf(err)
+/* func TestExecutedTestsGivenRequest(t *testing.T) { */
+/* 	path := "/driver_journeys" */
+/* 	method := http.MethodGet */
+/* 	r, err := http.NewRequest(method, path, strings.NewReader("")) */
+/* 	panicIf(err) */
 
-	report, err := ExecuteTestSuite(m, r, defaultTestFlags)
-	panicIf(err)
-	for _, a := range report.allAssertionResults {
-		if a.endpoint.Path != path || a.endpoint.Method != method {
-			t.Logf("Path expected by request: %s %s", method, path)
-			t.Logf("Assertion run for: %s %s", a.endpoint.Method, a.endpoint.Path)
-			t.Error("Unexpected assertion run for given request")
-		}
-	}
-}
+/* 	m := NewMockClientWithResponse(mockOKStatusResponse()) */
+/* 	report, err := TestRequest(m, r, defaultTestFlags) */
+/* 	panicIf(err) */
+/* 	for _, a := range report.assertionResults { */
+/* 		if a.endpoint.Path != path || a.endpoint.Method != method { */
+/* 			t.Logf("Path expected by request: %s %s", method, path) */
+/* 			t.Logf("Assertion run for: %s %s", a.endpoint.Method, a.endpoint.Path) */
+/* 			t.Error("Unexpected assertion run for given request") */
+/* 		} */
+/* 	} */
+/* } */
 
 func TestNoEmpty(t *testing.T) {
 	a := NewAssertionAccu()

--- a/cmd/test/test_suite_test.go
+++ b/cmd/test/test_suite_test.go
@@ -16,7 +16,7 @@ var defaultTestFlags Flags = Flags{DisallowEmpty: false}
 // testErrorOnRequestIsHandled returns an urlError for every API call and checks:
 // - that only one AssertionError is returned
 // - that AssertionError.Unwrap() != nil
-func testErrorOnRequestIsHandled(t *testing.T, f RequestTestFun) {
+func testErrorOnRequestIsHandled(t *testing.T, f requestTestFun) {
 	t.Helper()
 	t.Run("API call throws error", func(t *testing.T) {
 		urlError := &url.Error{Op: "", URL: "", Err: errors.New("error")}
@@ -38,7 +38,7 @@ func testErrorOnRequestIsHandled(t *testing.T, f RequestTestFun) {
 func TestAPIErrors(t *testing.T) {
 	for _, funs := range apiMapping {
 		for _, f := range funs {
-			testErrorOnRequestIsHandled(t, f)
+			testErrorOnRequestIsHandled(t, wrapTestResponseFun(f))
 		}
 	}
 }
@@ -54,8 +54,7 @@ func TestRequests(t *testing.T) {
 			m := NewMockClientWithResponse(mockOKStatusResponse())
 			r, err := http.NewRequest(http.MethodGet, url, strings.NewReader(""))
 			panicIf(err)
-			testNoAssertions := func(*http.Request, *http.Response,
-				AssertionAccumulator, Flags) []AssertionResult {
+			testNoAssertions := func(*http.Request, *http.Response, Flags) []AssertionResult {
 				return nil
 			}
 			wrapTestResponseFun(testNoAssertions)(m, r, defaultTestFlags)
@@ -69,7 +68,6 @@ func TestRequests(t *testing.T) {
 				t.Logf("Request expected: %+v", r)
 				t.Error("MockClient request is expected to be the one passed as argument")
 			}
-
 		})
 	}
 }


### PR DESCRIPTION
Two main changes : 
- `Report` has the responsibility for pretty printing, instead of AssertionResult which was too far in the calling chain.
- `requestTestFun` is now private and the type is only defined for better readability. Main testing type is now `ResponseTestFun`

As a result, the AssertionAccu can be created inside the `ResponseTestFun` level and does not need to be passed as parameter. Another change is that `SelectTestFuns` and `ExtractEndpoint` have been decoupled.