### PR TITLE
feat: improved user CLI

### DIFF
--- a/.github/workflows/go_tests_lint.yml
+++ b/.github/workflows/go_tests_lint.yml
@@ -50,5 +50,5 @@ jobs:
       - name: run server
         run: go run main.go serve &
       - name: test server
-        run: go run main.go test ./stdcov-cli --verbose --server "http://localhost:1323" --url /driver_journeys -q departureLat=0 -q departureLng=0 -q arrivalLat=0 -q arrivalLng=0 -q departureDate=1665500000 -q timeDelta=2000000000 -q departureRadius=500000 -q arrivalRadius=50000
+        run: go run main.go test ./stdcov-cli --verbose --url "http://localhost:1323/driver_journeys" -q departureLat=0 -q departureLng=0 -q arrivalLat=0 -q arrivalLng=0 -q departureDate=1665500000 -q timeDelta=2000000000 -q departureRadius=500000 -q arrivalRadius=50000
 

--- a/cmd/driverJourneys.go
+++ b/cmd/driverJourneys.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/fabmob/playground-standard-covoiturage/cmd/test"
@@ -18,7 +19,7 @@ Default query coordinates are placed on "Vesdun", a small town proclaimed "cente
 of France" by IGN in 1993.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		query := makeQuery()
-		test.Run(server, "/driver_journeys", verbose, query)
+		test.Run(http.MethodGet, "/driver_journeys", verbose, query, flags)
 	},
 }
 

--- a/cmd/driverJourneys.go
+++ b/cmd/driverJourneys.go
@@ -1,0 +1,85 @@
+package cmd
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/fabmob/playground-standard-covoiturage/cmd/test"
+	"github.com/spf13/cobra"
+)
+
+// driverJourneysCmd represents the driverJourneys command
+var driverJourneysCmd = &cobra.Command{
+	Use:   "driverJourneys",
+	Short: "Test the GET /driver_journeys endpoint",
+	Long: `Test the GET /driver_journeys endpoint
+
+Default query coordinates are placed on "Vesdun", a small town proclaimed "center
+of France" by IGN in 1993.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		query := makeQuery()
+		test.Run(server, "/driver_journeys", verbose, query)
+	},
+}
+
+var (
+	departureLat    string
+	departureLng    string
+	arrivalLat      string
+	arrivalLng      string
+	departureDate   string
+	timeDelta       string
+	departureRadius string
+	arrivalRadius   string
+	count           string
+)
+
+const (
+	vesdunLat = "46.588"
+	vesdunLng = "2.4284"
+)
+
+func init() {
+	driverJourneysCmd.Flags().StringVar(
+		&departureLat, "departureLat", vesdunLat, "departureLat query query parameter")
+	driverJourneysCmd.Flags().StringVar(
+		&departureLng, "departureLng", vesdunLng, "departureLng query parameter")
+	driverJourneysCmd.Flags().StringVar(
+		&arrivalLat, "arrivalLat", vesdunLat, "arrivalLat query parameter")
+	driverJourneysCmd.Flags().StringVar(
+		&arrivalLng, "arrivalLng", vesdunLng, "arrivalLng query parameter")
+	driverJourneysCmd.Flags().StringVar(
+		&departureDate, "departureDate", fmt.Sprintf("%d", time.Now().Unix()), "departureDate query parameter")
+	driverJourneysCmd.Flags().StringVar(
+		&timeDelta, "timeDelta", "", "timeDelta query parameter")
+	driverJourneysCmd.Flags().StringVar(
+		&departureRadius, "departureRadius", "", "departureRadius query parameter")
+	driverJourneysCmd.Flags().StringVar(
+		&arrivalRadius, "arrivalRadius", "", "arrivalRadius query parameter")
+	driverJourneysCmd.Flags().StringVar(
+		&count, "count", "", "count query parameter")
+
+	getCmd.AddCommand(driverJourneysCmd)
+}
+
+func makeQuery() test.Query {
+	var query = test.NewQuery()
+	query.Params["departureLat"] = departureLat
+	query.Params["departureLng"] = departureLng
+	query.Params["arrivalLat"] = arrivalLat
+	query.Params["arrivalLng"] = arrivalLng
+	query.Params["departureDate"] = departureDate
+	if timeDelta != "" {
+		query.Params["timeDelta"] = timeDelta
+	}
+	if departureRadius != "" {
+		query.Params["departureRadius"] = departureRadius
+	}
+	if arrivalRadius != "" {
+		query.Params["arrivalRadius"] = arrivalRadius
+	}
+	if count != "" {
+		query.Params["count"] = count
+	}
+	return query
+}

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -13,7 +13,10 @@ var getCmd = &cobra.Command{
 	Long:  "",
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			cmd.Help()
+			err := cmd.Help()
+			if err != nil {
+				panic(err)
+			}
 			os.Exit(0)
 		}
 	},

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// getCmd represents the get command
+var getCmd = &cobra.Command{
+	Use:   "get",
+	Short: "Interface for testing endpoints with method GET",
+	Long:  "",
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) == 0 {
+			cmd.Help()
+			os.Exit(0)
+		}
+	},
+}
+
+func init() {
+	testCmd.AddCommand(getCmd)
+}

--- a/cmd/passengerJourneys.go
+++ b/cmd/passengerJourneys.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/fabmob/playground-standard-covoiturage/cmd/test"
+	"github.com/spf13/cobra"
+)
+
+// passengerJourneysCmd represents the passengerJourneys command
+var passengerJourneysCmd = &cobra.Command{
+	Use:   "passengerJourneys",
+	Short: "Test the GET /passenger_journeys endpoint",
+	Long: `Test the GET /passenger_journeys endpoint
+
+Default query coordinates are placed on "Vesdun", a small town proclaimed "center
+of France" by IGN in 1993.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		query := makeQuery()
+		test.Run(server, "/passenger_journeys", verbose, query)
+	},
+}
+
+func init() {
+	driverJourneysCmd.Flags().StringVar(&departureLat, "departureLat", vesdunLat, "DepartureLat parameters in the form name = value")
+	driverJourneysCmd.Flags().StringVar(&departureLng, "departureLng", vesdunLng, "DepartureLng parameters in the form name = value")
+	driverJourneysCmd.Flags().StringVar(&arrivalLat, "arrivalLat", vesdunLat, "ArrivalLat parameters in the form name = value")
+	driverJourneysCmd.Flags().StringVar(&arrivalLng, "arrivalLng", vesdunLng, "ArrivalLng parameters in the form name = value")
+	driverJourneysCmd.Flags().StringVar(&departureDate, "departureDate", fmt.Sprintf("%d", time.Now().Unix()), "DepartureDate parameters in the form name = value")
+	driverJourneysCmd.Flags().StringVar(&timeDelta, "timeDelta", "", "TimeDelta parameters in the form name = value")
+	driverJourneysCmd.Flags().StringVar(&departureRadius, "departureRadius", "", "DepartureRadius parameters in the form name = value")
+	driverJourneysCmd.Flags().StringVar(&arrivalRadius, "arrivalRadius", "", "ArrivalRadius parameters in the form name = value")
+	driverJourneysCmd.Flags().StringVar(&count, "count", "", "Count parameters in the form name = value")
+
+	getCmd.AddCommand(passengerJourneysCmd)
+}

--- a/cmd/passengerJourneys.go
+++ b/cmd/passengerJourneys.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/fabmob/playground-standard-covoiturage/cmd/test"
@@ -18,20 +19,20 @@ Default query coordinates are placed on "Vesdun", a small town proclaimed "cente
 of France" by IGN in 1993.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		query := makeQuery()
-		test.Run(server, "/passenger_journeys", verbose, query)
+		test.Run(http.MethodGet, "/passenger_journeys", verbose, query, flags)
 	},
 }
 
 func init() {
-	driverJourneysCmd.Flags().StringVar(&departureLat, "departureLat", vesdunLat, "DepartureLat parameters in the form name = value")
-	driverJourneysCmd.Flags().StringVar(&departureLng, "departureLng", vesdunLng, "DepartureLng parameters in the form name = value")
-	driverJourneysCmd.Flags().StringVar(&arrivalLat, "arrivalLat", vesdunLat, "ArrivalLat parameters in the form name = value")
-	driverJourneysCmd.Flags().StringVar(&arrivalLng, "arrivalLng", vesdunLng, "ArrivalLng parameters in the form name = value")
-	driverJourneysCmd.Flags().StringVar(&departureDate, "departureDate", fmt.Sprintf("%d", time.Now().Unix()), "DepartureDate parameters in the form name = value")
-	driverJourneysCmd.Flags().StringVar(&timeDelta, "timeDelta", "", "TimeDelta parameters in the form name = value")
-	driverJourneysCmd.Flags().StringVar(&departureRadius, "departureRadius", "", "DepartureRadius parameters in the form name = value")
-	driverJourneysCmd.Flags().StringVar(&arrivalRadius, "arrivalRadius", "", "ArrivalRadius parameters in the form name = value")
-	driverJourneysCmd.Flags().StringVar(&count, "count", "", "Count parameters in the form name = value")
+	passengerJourneysCmd.Flags().StringVar(&departureLat, "departureLat", vesdunLat, "DepartureLat parameters in the form name = value")
+	passengerJourneysCmd.Flags().StringVar(&departureLng, "departureLng", vesdunLng, "DepartureLng parameters in the form name = value")
+	passengerJourneysCmd.Flags().StringVar(&arrivalLat, "arrivalLat", vesdunLat, "ArrivalLat parameters in the form name = value")
+	passengerJourneysCmd.Flags().StringVar(&arrivalLng, "arrivalLng", vesdunLng, "ArrivalLng parameters in the form name = value")
+	passengerJourneysCmd.Flags().StringVar(&departureDate, "departureDate", fmt.Sprintf("%d", time.Now().Unix()), "DepartureDate parameters in the form name = value")
+	passengerJourneysCmd.Flags().StringVar(&timeDelta, "timeDelta", "", "TimeDelta parameters in the form name = value")
+	passengerJourneysCmd.Flags().StringVar(&departureRadius, "departureRadius", "", "DepartureRadius parameters in the form name = value")
+	passengerJourneysCmd.Flags().StringVar(&arrivalRadius, "arrivalRadius", "", "ArrivalRadius parameters in the form name = value")
+	passengerJourneysCmd.Flags().StringVar(&count, "count", "", "Count parameters in the form name = value")
 
 	getCmd.AddCommand(passengerJourneysCmd)
 }

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"net/http"
+
 	"github.com/fabmob/playground-standard-covoiturage/cmd/test"
 	"github.com/spf13/cobra"
 )
@@ -16,22 +18,21 @@ Cobra is a CLI library for Go that empowers applications.
 This application is a tool to generate the needed files
 to quickly create a Cobra application.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		test.Run(server, url, verbose, query)
+		test.Run(http.MethodGet, url, verbose, query, flags)
 	},
 }
 
 var (
-	server        string
 	url           string
 	verbose       bool
 	query         test.Query
 	disallowEmpty bool
+	flags         = test.Flags{DisallowEmpty: false}
 )
 
 func init() {
 	rootCmd.AddCommand(testCmd)
 
-	testCmd.PersistentFlags().StringVarP(&server, "server", "s", "", "Server URL of the API under test")
 	testCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Make the operation more talkative")
 	testCmd.PersistentFlags().BoolVar(&disallowEmpty, "disallowEmpty", false,
 		"Should an empty request return an error")

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -30,10 +30,12 @@ var (
 
 func init() {
 	rootCmd.AddCommand(testCmd)
+
 	testCmd.PersistentFlags().StringVarP(&server, "server", "s", "", "Server URL of the API under test")
-	testCmd.PersistentFlags().StringVarP(&url, "url", "u", "", "API call URL")
 	testCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Make the operation more talkative")
-	testCmd.PersistentFlags().VarP(&query, "query", "q", "Query parameters in the form name=value")
 	testCmd.PersistentFlags().BoolVar(&disallowEmpty, "disallowEmpty", false,
 		"Should an empty request return an error")
+
+	testCmd.Flags().StringVarP(&url, "url", "u", "", "API call URL")
+	testCmd.Flags().VarP(&query, "query", "q", "Query parameters in the form name=value")
 }

--- a/cmd/test/api_mapping.go
+++ b/cmd/test/api_mapping.go
@@ -7,10 +7,11 @@ import (
 	"strings"
 )
 
-// apiMapping is the mapping between endpoint and the associated test
-// function that has been registered, if any
+// apiMapping stores api endpoint > test functions data
 var apiMapping = map[Endpoint]ResponseTestFun{}
 
+// GetAPIMapping returns the mapping between endpoint and the associated test
+// function
 func GetAPIMapping() map[Endpoint]ResponseTestFun {
 	if len(apiMapping) == 0 {
 		initAPIMapping()

--- a/cmd/test/api_mapping.go
+++ b/cmd/test/api_mapping.go
@@ -7,14 +7,21 @@ import (
 	"strings"
 )
 
-// APIMapping is the mapping between endpoint and the associated test
+// apiMapping is the mapping between endpoint and the associated test
 // function that has been registered, if any
-var APIMapping = map[Endpoint]ResponseTestFun{}
+var apiMapping = map[Endpoint]ResponseTestFun{}
+
+func GetAPIMapping() map[Endpoint]ResponseTestFun {
+	if len(apiMapping) == 0 {
+		initAPIMapping()
+	}
+	return apiMapping
+}
 
 // Register associates a test function to a given function. If any
 // TestFunction is already associated, it overwrites it.
 func Register(f ResponseTestFun, e Endpoint) {
-	APIMapping[e] = f
+	apiMapping[e] = f
 }
 
 // Endpoint describes an Endpoint
@@ -36,7 +43,7 @@ func (e Endpoint) emptyRequest() *http.Request {
 
 // SelectTestFuns returns the test functions related to a given request.
 func SelectTestFuns(endpoint Endpoint) (ResponseTestFun, error) {
-	testFun, ok := APIMapping[endpoint]
+	testFun, ok := GetAPIMapping()[endpoint]
 	if !ok {
 		return nil, fmt.Errorf("request to an unknown endpoint: %s", endpoint)
 	}
@@ -60,4 +67,31 @@ func ExtractEndpoint(request *http.Request, server string) (Endpoint, error) {
 	}
 
 	return Endpoint{method, path}, nil
+}
+
+// GuessServer try to guess the server, and returns server and path in case of
+// success.
+func GuessServer(method, URL string) (string, error) {
+	u, err := url.Parse(URL)
+	if err != nil {
+		return "", err
+	}
+
+	uWithoutQuery := u
+	uWithoutQuery.RawQuery = ""
+	uWithoutQuery.Fragment = ""
+
+	for endpoint := range GetAPIMapping() {
+		if endpoint.Method == method && strings.HasSuffix(uWithoutQuery.String(), endpoint.Path) {
+			fmt.Println("x")
+			server := strings.TrimSuffix(uWithoutQuery.String(), endpoint.Path)
+			return server, nil
+		}
+	}
+
+	return "", fmt.Errorf(
+		"did not recognize the endpoint with method %s in %s",
+		method,
+		uWithoutQuery,
+	)
 }

--- a/cmd/test/api_mapping_test.go
+++ b/cmd/test/api_mapping_test.go
@@ -56,3 +56,67 @@ func TestExtractEndpoint(t *testing.T) {
 		})
 	}
 }
+
+func TestGuessServer(t *testing.T) {
+	testCases := []struct {
+		name           string
+		method         string
+		requestURL     string
+		expectedServer string
+		expectError    bool
+	}{
+		{
+			"simple case 1",
+			http.MethodGet,
+			"https://localhost:1323/passenger_journeys",
+			"https://localhost:1323",
+			false,
+		},
+
+		{
+			"simple case 2",
+			http.MethodGet,
+			"https://localhost:1323/api/driver_journeys",
+			"https://localhost:1323/api",
+			false,
+		},
+
+		{
+			"wrong method",
+			http.MethodPost,
+			"https://localhost:1323/api/driver_journeys",
+			"",
+			true,
+		},
+
+		{
+			"more complex case 1: username & password",
+			http.MethodGet,
+			"http://username:password@example.com/a/b/c/driver_journeys",
+			"http://username:password@example.com/a/b/c",
+			false,
+		},
+
+		{
+			"more complex case 2: query",
+			http.MethodGet,
+			"http://example.com/a/b/c/driver_journeys?stuff=3",
+			"http://example.com/a/b/c",
+			false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			guessedServer, err := GuessServer(tc.method, tc.requestURL)
+			if tc.expectError != (err != nil) {
+				t.Fail()
+			}
+			if guessedServer != tc.expectedServer {
+				t.Logf("Expected server: %s", tc.expectedServer)
+				t.Logf("Got: %s (error %s)", guessedServer, err)
+				t.Fail()
+			}
+		})
+	}
+}

--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -3,27 +3,26 @@ package test
 import (
 	"fmt"
 	"net/http"
-	"net/url"
 )
 
 // Run runs the cli validation and returns an exit code
-func Run(server, endpoint string, verbose bool, query Query) int {
+func Run(method, URL string, verbose bool, query Query, flags Flags) int {
 
-	fullURL, _ := url.JoinPath(server, endpoint)
+	initAPIMapping()
 
-	req, err := http.NewRequest("GET", fullURL, nil)
+	server, err := GuessServer(method, URL)
+	if err != nil {
+		fmt.Println(err)
+		return 1
+	}
+
+	req, err := http.NewRequest(method, URL, nil)
 	if err != nil {
 		fmt.Println(err)
 		return 1
 	}
 
 	AddQueryParameters(query, req)
-
-	flags := Flags{
-		DisallowEmpty: false,
-	}
-
-	registerAllTests()
 
 	report, err := Request(server, req, flags)
 	if err != nil {

--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -4,19 +4,12 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-
-	"github.com/fabmob/playground-standard-covoiturage/cmd/api"
 )
 
 // Run runs the cli validation and returns an exit code
-func Run(server, URL string, verbose bool, query Query) int {
+func Run(server, endpoint string, verbose bool, query Query) int {
 
-	c, err := api.NewClient(server)
-	if err != nil {
-		panic(err)
-	}
-
-	fullURL, _ := url.JoinPath(server, URL)
+	fullURL, _ := url.JoinPath(server, endpoint)
 
 	req, err := http.NewRequest("GET", fullURL, nil)
 	if err != nil {
@@ -32,7 +25,7 @@ func Run(server, URL string, verbose bool, query Query) int {
 
 	registerAllTests()
 
-	report, err := Request(c, req, flags)
+	report, err := Request(server, req, flags)
 	if err != nil {
 		fmt.Println(err)
 		return 1

--- a/cmd/test/request.go
+++ b/cmd/test/request.go
@@ -11,6 +11,7 @@ type Query struct {
 	Params map[string]string
 }
 
+// NewQuery initializes an empty query
 func NewQuery() Query {
 	return Query{map[string]string{}}
 }

--- a/cmd/test/request.go
+++ b/cmd/test/request.go
@@ -8,14 +8,18 @@ import (
 
 // Query implements flag.Value interface to store query parameters
 type Query struct {
-	params map[string]string
+	Params map[string]string
+}
+
+func NewQuery() Query {
+	return Query{map[string]string{}}
 }
 
 // String implements pflag.Value.String (cobra flags)
 func (qp *Query) String() string {
 	var str = ""
 
-	for k, v := range qp.params {
+	for k, v := range qp.Params {
 		str += fmt.Sprintf("--%s:%s ", k, v)
 	}
 
@@ -32,11 +36,11 @@ func (qp *Query) Set(s string) error {
 		value = parts[1]
 	}
 
-	if qp.params == nil {
-		qp.params = make(map[string]string)
+	if qp.Params == nil {
+		qp.Params = make(map[string]string)
 	}
 
-	qp.params[key] = value
+	qp.Params[key] = value
 
 	return nil
 }
@@ -51,7 +55,7 @@ func (qp *Query) Type() string {
 func AddQueryParameters(query Query, req *http.Request) {
 	q := req.URL.Query()
 
-	for k, v := range query.params {
+	for k, v := range query.Params {
 		q.Add(k, v)
 	}
 

--- a/cmd/test/test_exported.go
+++ b/cmd/test/test_exported.go
@@ -2,8 +2,8 @@ package test
 
 import "net/http"
 
-// registerAllTests associates every available test to a given endpoint
-func registerAllTests() {
+// initAPIMapping associates every available test to a given endpoint
+func initAPIMapping() {
 	Register(TestGetStatusResponse, GetStatusEndpoint)
 	Register(TestGetDriverJourneysResponse, GetDriverJourneyEndpoint)
 	Register(TestGetPassengerJourneysResponse, GetPassengerJourneyEndpoint)

--- a/cmd/test/test_internals.go
+++ b/cmd/test/test_internals.go
@@ -17,7 +17,7 @@ func Request(server string, request *http.Request, flags Flags) (*Report, error)
 		return nil, err
 	}
 
-	endpoint, err := ExtractEndpoint(request, client.Server)
+	endpoint, err := ExtractEndpoint(request, server)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/test/test_internals.go
+++ b/cmd/test/test_internals.go
@@ -10,7 +10,13 @@ import (
 type APIClient = *api.Client
 
 // Request tests a request
-func Request(client APIClient, request *http.Request, flags Flags) (*Report, error) {
+func Request(server string, request *http.Request, flags Flags) (*Report, error) {
+
+	client, err := api.NewClient(server)
+	if err != nil {
+		return nil, err
+	}
+
 	endpoint, err := ExtractEndpoint(request, client.Server)
 	if err != nil {
 		return nil, err

--- a/cmd/test/test_internals_test.go
+++ b/cmd/test/test_internals_test.go
@@ -38,7 +38,7 @@ func testErrorOnRequestIsHandled(t *testing.T, f requestTestFun) {
 }
 
 func TestAPIErrors(t *testing.T) {
-	for _, fun := range apiMapping {
+	for _, fun := range GetAPIMapping() {
 		testErrorOnRequestIsHandled(t, wrapTestResponseFun(fun))
 	}
 }

--- a/cmd/test/test_internals_test.go
+++ b/cmd/test/test_internals_test.go
@@ -38,7 +38,7 @@ func testErrorOnRequestIsHandled(t *testing.T, f requestTestFun) {
 }
 
 func TestAPIErrors(t *testing.T) {
-	for _, fun := range APIMapping {
+	for _, fun := range apiMapping {
 		testErrorOnRequestIsHandled(t, wrapTestResponseFun(fun))
 	}
 }


### PR DESCRIPTION
Several equivalent ways of testing an API call : 

- Using the full URL with subcommand: 
```test --url https://server.com/driver_journeys?DepartureLat=x&...```
- or alternatively query parameters with -q flag:
```test --url https://server.com/driver_journeys -q departureLat=x -q ...```
- or through subcommands and flags:
```test get driverJourneys --departureLat=x ...```

Somewhat clunky code for the third option, as all parameters are passed as `string`, so the --help text does not hint the real expected types. 

