### PR TITLE
fix: missing server parameter

### DIFF
--- a/cmd/driverJourneys.go
+++ b/cmd/driverJourneys.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/fabmob/playground-standard-covoiturage/cmd/test"
@@ -19,7 +20,8 @@ Default query coordinates are placed on "Vesdun", a small town proclaimed "cente
 of France" by IGN in 1993.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		query := makeQuery()
-		test.Run(http.MethodGet, "/driver_journeys", verbose, query, flags)
+		URL, _ := url.JoinPath(server, "/driver_journeys")
+		test.Run(http.MethodGet, URL, verbose, query, flags)
 	},
 }
 

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -22,6 +22,11 @@ var getCmd = &cobra.Command{
 	},
 }
 
+var (
+	server string
+)
+
 func init() {
+	getCmd.PersistentFlags().StringVar(&server, "server", "", "Server on which to run the query")
 	testCmd.AddCommand(getCmd)
 }

--- a/cmd/passengerJourneys.go
+++ b/cmd/passengerJourneys.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/fabmob/playground-standard-covoiturage/cmd/test"
@@ -19,7 +20,8 @@ Default query coordinates are placed on "Vesdun", a small town proclaimed "cente
 of France" by IGN in 1993.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		query := makeQuery()
-		test.Run(http.MethodGet, "/passenger_journeys", verbose, query, flags)
+		URL, _ := url.JoinPath(server, "/passenger_journeys")
+		test.Run(http.MethodGet, URL, verbose, query, flags)
 	},
 }
 

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -18,12 +18,12 @@ Cobra is a CLI library for Go that empowers applications.
 This application is a tool to generate the needed files
 to quickly create a Cobra application.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		test.Run(http.MethodGet, url, verbose, query, flags)
+		test.Run(http.MethodGet, URL, verbose, query, flags)
 	},
 }
 
 var (
-	url           string
+	URL           string
 	verbose       bool
 	query         test.Query
 	disallowEmpty bool
@@ -37,6 +37,6 @@ func init() {
 	testCmd.PersistentFlags().BoolVar(&disallowEmpty, "disallowEmpty", false,
 		"Should an empty request return an error")
 
-	testCmd.Flags().StringVarP(&url, "url", "u", "", "API call URL")
+	testCmd.Flags().StringVarP(&URL, "url", "u", "", "API call URL")
 	testCmd.Flags().VarP(&query, "query", "q", "Query parameters in the form name=value")
 }


### PR DESCRIPTION
The subcommands `test get driverJourneys` and `test get passengerJourneys` had no way of specifying a server. 

This is now done with the `--server` flag. 