### PR TITLE
feat(bookings): implement (mock) command for GET /bookings/{bookingID}

### DIFF
--- a/.github/workflows/go_tests_lint.yml
+++ b/.github/workflows/go_tests_lint.yml
@@ -49,6 +49,6 @@ jobs:
           go-version: 1.19
       - name: run server
         run: go run main.go serve &
-      - name: test server
-        run: go run main.go test ./stdcov-cli --verbose --url "http://localhost:1323/driver_journeys" -q departureLat=0 -q departureLng=0 -q arrivalLat=0 -q arrivalLng=0 -q departureDate=1665500000 -q timeDelta=2000000000 -q departureRadius=500000 -q arrivalRadius=50000
+      - name: test commands
+        run: bash cmd/test/test_commands.sh
 

--- a/cmd/bookings.go
+++ b/cmd/bookings.go
@@ -1,10 +1,9 @@
 package cmd
 
 import (
-	"fmt"
+	"errors"
 	"net/http"
 	"net/url"
-	"os"
 
 	"github.com/fabmob/playground-standard-covoiturage/cmd/test"
 	"github.com/spf13/cobra"
@@ -12,13 +11,14 @@ import (
 
 // bookingsCmd represents the bookings command
 var bookingsCmd = &cobra.Command{
-	Use:   "bookings",
-	Short: "Test the GET /bookings endpoint",
-	Long:  `Test the GET /bookings endpoint`,
+	Use:     "bookings",
+	Short:   "Test the GET /bookings endpoint",
+	Long:    `Test the GET /bookings endpoint`,
+	PreRunE: checkGetBookingsCmdFlags,
 	Run: func(cmd *cobra.Command, args []string) {
-		checkRequiredGetBookingsArguments(server, bookingID)
 		URL, _ := url.JoinPath(server, "/bookings", bookingID)
-		test.Run(http.MethodGet, URL, verbose, test.NewQuery(), flags())
+		err := test.Run(http.MethodGet, URL, verbose, test.NewQuery(), flags())
+		exitWithError(err)
 	},
 }
 
@@ -33,13 +33,10 @@ func init() {
 	getCmd.AddCommand(bookingsCmd)
 }
 
-func checkRequiredGetBookingsArguments(server, bookingID string) {
-	if server == "" {
-		fmt.Println("Server information is missing, but required. It can be passed with the --server flag.")
-		os.Exit(0)
-	}
+func checkGetBookingsCmdFlags(cmd *cobra.Command, args []string) error {
 	if bookingID == "" {
-		fmt.Println("bookingId path parameter is missing, but required. It can be passed with the --bookingId flag.")
-		os.Exit(0)
+		return errors.New("missing required --bookingId information")
 	}
+
+	return nil
 }

--- a/cmd/bookings.go
+++ b/cmd/bookings.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+
+	"github.com/fabmob/playground-standard-covoiturage/cmd/test"
+	"github.com/spf13/cobra"
+)
+
+// bookingsCmd represents the bookings command
+var bookingsCmd = &cobra.Command{
+	Use:   "bookings",
+	Short: "Test the GET /bookings endpoint",
+	Long:  `Test the GET /bookings endpoint`,
+	Run: func(cmd *cobra.Command, args []string) {
+		checkRequiredGetBookingsArguments(server, bookingID)
+		URL, _ := url.JoinPath(server, "/bookings", bookingID)
+		test.Run(http.MethodGet, URL, verbose, test.NewQuery(), flags())
+	},
+}
+
+var (
+	bookingID string
+)
+
+func init() {
+	bookingsCmd.Flags().StringVar(
+		&bookingID, "bookingId", "", "bookingIdpath parameter",
+	)
+	getCmd.AddCommand(bookingsCmd)
+}
+
+func checkRequiredGetBookingsArguments(server, bookingID string) {
+	if server == "" {
+		fmt.Println("Server information is missing, but required. It can be passed with the --server flag.")
+		os.Exit(0)
+	}
+	if bookingID == "" {
+		fmt.Println("bookingId path parameter is missing, but required. It can be passed with the --bookingId flag.")
+		os.Exit(0)
+	}
+}

--- a/cmd/driverJourneys.go
+++ b/cmd/driverJourneys.go
@@ -21,7 +21,8 @@ of France" by IGN in 1993.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		query := makeQuery()
 		URL, _ := url.JoinPath(server, "/driver_journeys")
-		test.Run(http.MethodGet, URL, verbose, query, flags())
+		err := test.Run(http.MethodGet, URL, verbose, query, flags())
+		exitWithError(err)
 	},
 }
 

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -8,9 +8,10 @@ import (
 
 // getCmd represents the get command
 var getCmd = &cobra.Command{
-	Use:   "get",
-	Short: "Interface for testing endpoints with method GET",
-	Long:  "",
+	Use:               "get",
+	Short:             "Interface for testing endpoints with method GET",
+	Long:              "",
+	PersistentPreRunE: checkGetCmdFlags,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
 			err := cmd.Help()
@@ -29,4 +30,8 @@ var (
 func init() {
 	getCmd.PersistentFlags().StringVar(&server, "server", "", "Server on which to run the query")
 	testCmd.AddCommand(getCmd)
+}
+
+func checkGetCmdFlags(cmd *cobra.Command, args []string) error {
+	return nil
 }

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -18,6 +19,7 @@ var getCmd = &cobra.Command{
 			if err != nil {
 				panic(err)
 			}
+
 			os.Exit(0)
 		}
 	},
@@ -33,5 +35,9 @@ func init() {
 }
 
 func checkGetCmdFlags(cmd *cobra.Command, args []string) error {
+	if server == "" {
+		return errors.New("missing required --server information")
+	}
+
 	return nil
 }

--- a/cmd/passengerJourneys.go
+++ b/cmd/passengerJourneys.go
@@ -21,7 +21,8 @@ of France" by IGN in 1993.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		query := makeQuery()
 		URL, _ := url.JoinPath(server, "/passenger_journeys")
-		test.Run(http.MethodGet, URL, verbose, query, flags())
+		err := test.Run(http.MethodGet, URL, verbose, query, flags())
+		exitWithError(err)
 	},
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -19,19 +20,14 @@ var rootCmd = &cobra.Command{
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	err := rootCmd.Execute()
-	if err != nil {
-		os.Exit(1)
-	}
+	exitWithError(err)
 }
 
-func init() {
-	// Here you will define your flags and configuration settings.
-	// Cobra supports persistent flags, which, if defined here,
-	// will be global for your application.
+func init() {}
 
-	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.stdcov-api-test.yaml)")
-
-	// Cobra also supports local flags, which will only run
-	// when this action is called directly.
-	/* rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle") */
+func exitWithError(err error) {
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 }

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -18,7 +18,8 @@ Cobra is a CLI library for Go that empowers applications.
 This application is a tool to generate the needed files
 to quickly create a Cobra application.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		test.Run(http.MethodGet, URL, verbose, query, flags())
+		err := test.Run(http.MethodGet, URL, verbose, query, flags())
+		exitWithError(err)
 	},
 }
 

--- a/cmd/test/api_mapping.go
+++ b/cmd/test/api_mapping.go
@@ -62,31 +62,6 @@ func SelectTestFuns(endpoint Endpoint) (ResponseTestFun, error) {
 	return testFun, nil
 }
 
-// ExtractEndpoint extracts the endpoint from a request, given server
-// information
-func ExtractEndpoint(request *http.Request, server string) (Endpoint, error) {
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return Endpoint{}, err
-	}
-
-	method := request.Method
-
-	path := strings.TrimPrefix(request.URL.Path, serverURL.Path)
-	path = ensureLeadingSlash(path)
-	firstPathSegment := firstPathSegment(path)
-
-	return NewEndpoint(method, firstPathSegment), nil
-}
-
-func ensureLeadingSlash(path string) string {
-	if strings.HasPrefix(path, "/") {
-		return path
-	}
-
-	return "/" + path
-}
-
 // firstPathSegment assumes without checking that path has a leading slash
 func firstPathSegment(path string) string {
 	return "/" + strings.Split(path, "/")[1]
@@ -130,7 +105,7 @@ func knownEndpointSuffix(url string, endpoint Endpoint) string {
 	var param string
 	if endpoint.HasPathParam {
 		url, param = path.Split(url)
-		url = removeTrailingSlash(url)
+		url = ensureNoTrailingSlash(url)
 		param = ensureLeadingSlash(param)
 	}
 
@@ -141,6 +116,14 @@ func knownEndpointSuffix(url string, endpoint Endpoint) string {
 	return ""
 }
 
-func removeTrailingSlash(s string) string {
+func ensureNoTrailingSlash(s string) string {
 	return strings.TrimSuffix(s, "/")
+}
+
+func ensureLeadingSlash(path string) string {
+	if strings.HasPrefix(path, "/") {
+		return path
+	}
+
+	return "/" + path
 }

--- a/cmd/test/api_mapping.go
+++ b/cmd/test/api_mapping.go
@@ -62,11 +62,6 @@ func SelectTestFuns(endpoint Endpoint) (ResponseTestFun, error) {
 	return testFun, nil
 }
 
-// firstPathSegment assumes without checking that path has a leading slash
-func firstPathSegment(path string) string {
-	return "/" + strings.Split(path, "/")[1]
-}
-
 // SplitServerEndpoint try to guess the server, and returns server and path in case of
 // success.
 func SplitServerEndpoint(method, URL string) (string, Endpoint, error) {

--- a/cmd/test/api_mapping.go
+++ b/cmd/test/api_mapping.go
@@ -63,11 +63,23 @@ func ExtractEndpoint(request *http.Request, server string) (Endpoint, error) {
 	method := request.Method
 
 	path := strings.TrimPrefix(request.URL.Path, serverURL.Path)
-	if !strings.HasPrefix(path, "/") {
-		path = "/" + path
+	path = ensureLeadingSlash(path)
+	firstPathSegment := firstPathSegment(path)
+
+	return Endpoint{method, firstPathSegment}, nil
+}
+
+func ensureLeadingSlash(path string) string {
+	if strings.HasPrefix(path, "/") {
+		return path
 	}
 
-	return Endpoint{method, path}, nil
+	return "/" + path
+}
+
+// firstPathSegment assumes without checking that path has a leading slash
+func firstPathSegment(path string) string {
+	return "/" + strings.Split(path, "/")[1]
 }
 
 // GuessServer try to guess the server, and returns server and path in case of

--- a/cmd/test/api_mapping_test.go
+++ b/cmd/test/api_mapping_test.go
@@ -5,78 +5,21 @@ import (
 	"testing"
 )
 
-func TestExtractEndpoint(t *testing.T) {
-	testCases := []struct {
-		name                 string
-		method               string
-		requestURL           string
-		server               string
-		expectedEndpointPath string
-	}{
-		{
-			"relative url",
-			http.MethodGet,
-			"/driver_journeys",
-			"",
-			"/driver_journeys",
-		},
-		{
-			"absolute url with trailing slash, api at root",
-			http.MethodGet,
-			"https://localhost:1323/driver_journeys",
-			"https://localhost:1323/",
-			"/driver_journeys",
-		},
-		{
-			"absolute url without trailing slash, api at root",
-			http.MethodGet,
-			"https://localhost:1323/driver_journeys",
-			"https://localhost:1323/",
-			"/driver_journeys",
-		},
-		{
-			"absolute url, api not at root",
-			http.MethodGet,
-			"https://localhost:1323/api/driver_journeys",
-			"https://localhost:1323/api/",
-			"/driver_journeys",
-		},
-		{
-			"/get bookings endpoint",
-			http.MethodGet,
-			"https://localhost:1323/bookings/1234",
-			"https://localhost:1323/api/",
-			"/bookings",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			request, err := http.NewRequest(tc.method, tc.requestURL, nil)
-			panicIf(err)
-			endpoint, _ := ExtractEndpoint(request, tc.server)
-			if endpoint.Method != tc.method || endpoint.Path != tc.expectedEndpointPath {
-				t.Logf("Method : exected %s, got %s", tc.method, endpoint.Method)
-				t.Logf("Path : exected %s, got %s", tc.expectedEndpointPath, endpoint.Path)
-				t.Error("Failure to identify right endpoint from request")
-			}
-		})
-	}
-}
-
 func TestSplitServerEndpoint(t *testing.T) {
 	testCases := []struct {
-		name           string
-		method         string
-		requestURL     string
-		expectedServer string
-		expectError    bool
+		name             string
+		method           string
+		requestURL       string
+		expectedServer   string
+		expectedEndpoint Endpoint
+		expectError      bool
 	}{
 		{
 			"simple case 1",
 			http.MethodGet,
 			"https://localhost:1323/passenger_journeys",
 			"https://localhost:1323",
+			GetPassengerJourneysEndpoint,
 			false,
 		},
 
@@ -85,6 +28,7 @@ func TestSplitServerEndpoint(t *testing.T) {
 			http.MethodGet,
 			"https://localhost:1323/api/driver_journeys",
 			"https://localhost:1323/api",
+			GetDriverJourneysEndpoint,
 			false,
 		},
 
@@ -93,6 +37,7 @@ func TestSplitServerEndpoint(t *testing.T) {
 			http.MethodPost,
 			"https://localhost:1323/api/driver_journeys",
 			"",
+			GetDriverJourneysEndpoint,
 			true,
 		},
 
@@ -101,6 +46,7 @@ func TestSplitServerEndpoint(t *testing.T) {
 			http.MethodGet,
 			"http://username:password@example.com/a/b/c/driver_journeys",
 			"http://username:password@example.com/a/b/c",
+			GetDriverJourneysEndpoint,
 			false,
 		},
 
@@ -109,6 +55,7 @@ func TestSplitServerEndpoint(t *testing.T) {
 			http.MethodGet,
 			"http://example.com/a/b/c/driver_journeys?stuff=3",
 			"http://example.com/a/b/c",
+			GetDriverJourneysEndpoint,
 			false,
 		},
 
@@ -117,6 +64,7 @@ func TestSplitServerEndpoint(t *testing.T) {
 			http.MethodGet,
 			"http://example.com/bookings/1234",
 			"http://example.com",
+			GetBookingsEndpoint,
 			false,
 		},
 	}

--- a/cmd/test/api_mapping_test.go
+++ b/cmd/test/api_mapping_test.go
@@ -37,7 +37,7 @@ func TestSplitServerEndpoint(t *testing.T) {
 			http.MethodPost,
 			"https://localhost:1323/api/driver_journeys",
 			"",
-			GetDriverJourneysEndpoint,
+			Endpoint{},
 			true,
 		},
 
@@ -71,13 +71,18 @@ func TestSplitServerEndpoint(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			guessedServer, _, err := SplitServerEndpoint(tc.method, tc.requestURL)
+			guessedServer, guessedEndpoint, err := SplitServerEndpoint(tc.method, tc.requestURL)
 			if tc.expectError != (err != nil) {
 				t.Fail()
 			}
 			if guessedServer != tc.expectedServer {
 				t.Logf("Expected server: %s", tc.expectedServer)
 				t.Logf("Got: %s (error %s)", guessedServer, err)
+				t.Fail()
+			}
+			if guessedEndpoint != tc.expectedEndpoint {
+				t.Logf("Expected endpoint: %s", tc.expectedEndpoint)
+				t.Logf("Got: %s (error %s)", guessedEndpoint, err)
 				t.Fail()
 			}
 		})

--- a/cmd/test/api_mapping_test.go
+++ b/cmd/test/api_mapping_test.go
@@ -111,6 +111,14 @@ func TestGuessServer(t *testing.T) {
 			"http://example.com/a/b/c",
 			false,
 		},
+
+		{
+			"more complex case 3: path parameter",
+			http.MethodGet,
+			"http://example.com/bookings/1234",
+			"http://example.com",
+			false,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/cmd/test/api_mapping_test.go
+++ b/cmd/test/api_mapping_test.go
@@ -41,6 +41,13 @@ func TestExtractEndpoint(t *testing.T) {
 			"https://localhost:1323/api/",
 			"/driver_journeys",
 		},
+		{
+			"/get bookings endpoint",
+			http.MethodGet,
+			"https://localhost:1323/bookings/1234",
+			"https://localhost:1323/api/",
+			"/bookings",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/cmd/test/api_mapping_test.go
+++ b/cmd/test/api_mapping_test.go
@@ -64,7 +64,7 @@ func TestExtractEndpoint(t *testing.T) {
 	}
 }
 
-func TestGuessServer(t *testing.T) {
+func TestSplitServerEndpoint(t *testing.T) {
 	testCases := []struct {
 		name           string
 		method         string
@@ -123,7 +123,7 @@ func TestGuessServer(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			guessedServer, err := GuessServer(tc.method, tc.requestURL)
+			guessedServer, _, err := SplitServerEndpoint(tc.method, tc.requestURL)
 			if tc.expectError != (err != nil) {
 				t.Fail()
 			}

--- a/cmd/test/assertion_implementation_test.go
+++ b/cmd/test/assertion_implementation_test.go
@@ -134,7 +134,7 @@ func TestExpectDriverJourneysFormat(t *testing.T) {
 
 	var (
 		// Test requests
-		driverJourneysRequest    = GetDriverJourneyEndpoint.emptyRequest()
+		driverJourneysRequest    = GetDriverJourneysEndpoint.emptyRequest()
 		passengerJourneysRequest = GetPassengerJourneysEndpoint.emptyRequest()
 
 		// Test bodies

--- a/cmd/test/assertion_implementation_test.go
+++ b/cmd/test/assertion_implementation_test.go
@@ -135,7 +135,7 @@ func TestExpectDriverJourneysFormat(t *testing.T) {
 	var (
 		// Test requests
 		driverJourneysRequest    = GetDriverJourneyEndpoint.emptyRequest()
-		passengerJourneysRequest = GetPassengerJourneyEndpoint.emptyRequest()
+		passengerJourneysRequest = GetPassengerJourneysEndpoint.emptyRequest()
 
 		// Test bodies
 		emptyDriverJourneysBody    = marshalBody([]api.DriverJourney{})

--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -8,8 +8,6 @@ import (
 // Run runs the cli validation and returns an exit code
 func Run(method, URL string, verbose bool, query Query, flags Flags) int {
 
-	initAPIMapping()
-
 	req, err := http.NewRequest(method, URL, nil)
 	if err != nil {
 		fmt.Println(err)

--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -3,31 +3,31 @@ package test
 import (
 	"fmt"
 	"net/http"
+
+	"github.com/pkg/errors"
 )
 
 // Run runs the cli validation and returns an exit code
-func Run(method, URL string, verbose bool, query Query, flags Flags) int {
+func Run(method, URL string, verbose bool, query Query, flags Flags) error {
 
 	req, err := http.NewRequest(method, URL, nil)
 	if err != nil {
-		fmt.Println(err)
-		return 1
+		return err
 	}
 
 	AddQueryParameters(query, req)
 
 	report, err := Request(req, flags)
 	if err != nil {
-		fmt.Println(err)
-		return 1
+		return err
 	}
 
 	report.verbose = verbose
 	fmt.Println(report)
 
 	if report.hasErrors() {
-		return 1
+		return errors.New(report.String())
 	}
 
-	return 0
+	return nil
 }

--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -10,12 +10,6 @@ func Run(method, URL string, verbose bool, query Query, flags Flags) int {
 
 	initAPIMapping()
 
-	server, err := GuessServer(method, URL)
-	if err != nil {
-		fmt.Println(err)
-		return 1
-	}
-
 	req, err := http.NewRequest(method, URL, nil)
 	if err != nil {
 		fmt.Println(err)
@@ -24,7 +18,7 @@ func Run(method, URL string, verbose bool, query Query, flags Flags) int {
 
 	AddQueryParameters(query, req)
 
-	report, err := Request(server, req, flags)
+	report, err := Request(req, flags)
 	if err != nil {
 		fmt.Println(err)
 		return 1

--- a/cmd/test/report_test.go
+++ b/cmd/test/report_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestReport(t *testing.T) {
-	endpoint := Endpoint{http.MethodGet, "/endpoint_path"}
+	endpoint := NewEndpoint(http.MethodGet, "/endpoint_path")
 	assertStr := "test assertion"
 	errorDescription := "Error description"
 

--- a/cmd/test/test_commands.sh
+++ b/cmd/test/test_commands.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Testing different testing commands. To be run inside the project root
+# directory. The commands are not expected to test any data.
+
+# exit when any command fails
+set -e
+set -o pipefail
+
+echo "Run fake server"
+go run main.go serve > /dev/null &
+sleep 1
+
+echo "Test GET /driver_journeys with url"
+go run main.go test \
+  --url "http://localhost:1323/driver_journeys" \
+  -q departureLat=0 \
+  -q departureLng=0 \
+  -q arrivalLat=0 \
+  -q arrivalLng=0 \
+  -q departureDate=0 \
+  -q timeDelta=0 \
+  -q departureRadius=0 \
+  -q arrivalRadius=0
+
+
+echo "Test GET /passenger_journeys with short command, no optional query parameter"
+go run main.go test get passengerJourneys --server "http://localhost:1323" --departureLat=0 --departureLng=0 --arrivalLat=0 --arrivalLng=0 --departureDate=0
+
+
+echo "Test GET /passenger_journeys with short command, all optional query parameter"
+go run main.go test get passengerJourneys --server "http://localhost:1323" --departureLat=0 --departureLng=0 --arrivalLat=0 --arrivalLng=0 --departureDate=0
+
+# echo "Test GET /bookings/{bookingId} with short command"
+# go run main.go test get bookings --server "http://localhost:1323" --bookingId="42"
+
+# Clean up subprocesses on exit
+trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT

--- a/cmd/test/test_commands.sh
+++ b/cmd/test/test_commands.sh
@@ -7,6 +7,11 @@
 set -e
 set -o pipefail
 
+# Clean up subprocesses on exit
+# Do not use builtin bash `kill` command
+enable -n kill
+trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
+
 echo "Run fake server"
 go run main.go serve > /dev/null &
 sleep 1
@@ -34,5 +39,3 @@ go run main.go test get passengerJourneys --server "http://localhost:1323" --dep
 # echo "Test GET /bookings/{bookingId} with short command"
 # go run main.go test get bookings --server "http://localhost:1323" --bookingId="42"
 
-# Clean up subprocesses on exit
-trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT

--- a/cmd/test/test_commands.sh
+++ b/cmd/test/test_commands.sh
@@ -3,21 +3,12 @@
 # Testing different testing commands. To be run inside the project root
 # directory. The commands are not expected to test any data.
 
+# The fake server must run on http://localhost:1323 for the tests to pass
+
 # exit when any command fails
 set -e
 set -o pipefail
 
-
-echo "Run fake server"
-go run main.go serve > /dev/null &
-pid=$!
-
-# Clean up subprocesses on exit
-# Do not use builtin bash `kill` command
-enable -n kill
-trap 'trap - SIGTERM && kill $pid' SIGINT SIGTERM EXIT
-
-sleep 2
 
 echo "Test GET /driver_journeys with url"
 go run main.go test \
@@ -41,4 +32,3 @@ go run main.go test get passengerJourneys --server "http://localhost:1323" --dep
 
 # echo "Test GET /bookings/{bookingId} with short command"
 # go run main.go test get bookings --server "http://localhost:1323" --bookingId="42"
-

--- a/cmd/test/test_commands.sh
+++ b/cmd/test/test_commands.sh
@@ -30,5 +30,5 @@ go run main.go test get passengerJourneys --server "http://localhost:1323" --dep
 echo "Test GET /passenger_journeys with short command, all optional query parameter"
 go run main.go test get passengerJourneys --server "http://localhost:1323" --departureLat=0 --departureLng=0 --arrivalLat=0 --arrivalLng=0 --departureDate=0
 
-# echo "Test GET /bookings/{bookingId} with short command"
-# go run main.go test get bookings --server "http://localhost:1323" --bookingId="42"
+echo "Test GET /bookings/{bookingId} with short command"
+go run main.go test get bookings --server "http://localhost:1323" --bookingId="42"

--- a/cmd/test/test_commands.sh
+++ b/cmd/test/test_commands.sh
@@ -7,14 +7,17 @@
 set -e
 set -o pipefail
 
-# Clean up subprocesses on exit
-# Do not use builtin bash `kill` command
-enable -n kill
-trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
 
 echo "Run fake server"
 go run main.go serve > /dev/null &
-sleep 1
+pid=$!
+
+# Clean up subprocesses on exit
+# Do not use builtin bash `kill` command
+enable -n kill
+trap 'trap - SIGTERM && kill $pid' SIGINT SIGTERM EXIT
+
+sleep 2
 
 echo "Test GET /driver_journeys with url"
 go run main.go test \

--- a/cmd/test/test_exported.go
+++ b/cmd/test/test_exported.go
@@ -5,7 +5,7 @@ import "net/http"
 // initAPIMapping associates every available test to a given endpoint
 func initAPIMapping() {
 	Register(TestGetStatusResponse, GetStatusEndpoint)
-	Register(TestGetDriverJourneysResponse, GetDriverJourneyEndpoint)
+	Register(TestGetDriverJourneysResponse, GetDriverJourneysEndpoint)
 	Register(TestGetPassengerJourneysResponse, GetPassengerJourneysEndpoint)
 	Register(TestGetBookingsResponse, GetBookingsEndpoint)
 }
@@ -32,8 +32,8 @@ var (
 var (
 	// GetStatusEndpoint is the Endpoint of GET /status
 	GetStatusEndpoint = NewEndpoint(http.MethodGet, "/status")
-	// GetDriverJourneyEndpoint is the Endpoint of GET /driver_journeys
-	GetDriverJourneyEndpoint = NewEndpoint(http.MethodGet, "/driver_journeys")
+	// GetDriverJourneysEndpoint is the Endpoint of GET /driver_journeys
+	GetDriverJourneysEndpoint = NewEndpoint(http.MethodGet, "/driver_journeys")
 	// GetPassengerJourneysEndpoint is the Endpoint of GET /passenger_journeys
 	GetPassengerJourneysEndpoint = NewEndpoint(http.MethodGet, "/passenger_journeys")
 	// GetBookingsEndpoint is the Endpoint of GET /passenger_journeys

--- a/cmd/test/test_exported.go
+++ b/cmd/test/test_exported.go
@@ -6,7 +6,8 @@ import "net/http"
 func initAPIMapping() {
 	Register(TestGetStatusResponse, GetStatusEndpoint)
 	Register(TestGetDriverJourneysResponse, GetDriverJourneyEndpoint)
-	Register(TestGetPassengerJourneysResponse, GetPassengerJourneyEndpoint)
+	Register(TestGetPassengerJourneysResponse, GetPassengerJourneysEndpoint)
+	Register(TestGetBookingsResponse, GetBookingsEndpoint)
 }
 
 //////////////////////////////////////////////////////////////
@@ -20,6 +21,8 @@ var (
 	TestGetDriverJourneysResponse = wrapAssertionsFun(testGetDriverJourneys)
 	// TestGetPassengerJourneysResponse tests response of GET /passenger_journeys
 	TestGetPassengerJourneysResponse = wrapAssertionsFun(testGetPassengerJourneys)
+	// TestGetBookingsResponse tests response of GET /bookings/{booking_id}
+	TestGetBookingsResponse = wrapAssertionsFun(testGetBookings)
 )
 
 //////////////////////////////////////////////////////////////
@@ -31,6 +34,8 @@ var (
 	GetStatusEndpoint = Endpoint{http.MethodGet, "/status"}
 	// GetDriverJourneyEndpoint is the Endpoint of GET /driver_journeys
 	GetDriverJourneyEndpoint = Endpoint{http.MethodGet, "/driver_journeys"}
-	// GetPassengerJourneyEndpoint is the Endpoint of GET /passenger_journeys
-	GetPassengerJourneyEndpoint = Endpoint{http.MethodGet, "/passenger_journeys"}
+	// GetPassengerJourneysEndpoint is the Endpoint of GET /passenger_journeys
+	GetPassengerJourneysEndpoint = Endpoint{http.MethodGet, "/passenger_journeys"}
+	// GetBookingsEndpoint is the Endpoint of GET /passenger_journeys
+	GetBookingsEndpoint = Endpoint{http.MethodGet, "/booking"}
 )

--- a/cmd/test/test_exported.go
+++ b/cmd/test/test_exported.go
@@ -31,11 +31,11 @@ var (
 
 var (
 	// GetStatusEndpoint is the Endpoint of GET /status
-	GetStatusEndpoint = Endpoint{http.MethodGet, "/status"}
+	GetStatusEndpoint = NewEndpoint(http.MethodGet, "/status")
 	// GetDriverJourneyEndpoint is the Endpoint of GET /driver_journeys
-	GetDriverJourneyEndpoint = Endpoint{http.MethodGet, "/driver_journeys"}
+	GetDriverJourneyEndpoint = NewEndpoint(http.MethodGet, "/driver_journeys")
 	// GetPassengerJourneysEndpoint is the Endpoint of GET /passenger_journeys
-	GetPassengerJourneysEndpoint = Endpoint{http.MethodGet, "/passenger_journeys"}
+	GetPassengerJourneysEndpoint = NewEndpoint(http.MethodGet, "/passenger_journeys")
 	// GetBookingsEndpoint is the Endpoint of GET /passenger_journeys
-	GetBookingsEndpoint = Endpoint{http.MethodGet, "/booking"}
+	GetBookingsEndpoint = NewEndpointWithParam(http.MethodGet, "/bookings")
 )

--- a/cmd/test/test_implementation.go
+++ b/cmd/test/test_implementation.go
@@ -51,3 +51,11 @@ func testGetPassengerJourneys(
 	// Passenger journeys are very similar to driver journeys.
 	testGetDriverJourneys(request, response, a, flags)
 }
+
+func testGetBookings(
+	request *http.Request,
+	response *http.Response,
+	a AssertionAccumulator,
+	flags Flags,
+) {
+}

--- a/cmd/test/test_internals.go
+++ b/cmd/test/test_internals.go
@@ -10,14 +10,14 @@ import (
 type APIClient = *api.Client
 
 // Request tests a request
-func Request(server string, request *http.Request, flags Flags) (*Report, error) {
+func Request(request *http.Request, flags Flags) (*Report, error) {
 
-	client, err := api.NewClient(server)
+	server, endpoint, err := SplitServerEndpoint(request.Method, request.URL.String())
 	if err != nil {
 		return nil, err
 	}
 
-	endpoint, err := ExtractEndpoint(request, server)
+	client, err := api.NewClient(server)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
* Implements empty `TestGetBookingsResponse`. 
* Test and implement cobra subcommand : 
`./pscovoit test get bookings --server="xxx" --bookingId="0000"`

Fix: 
- A failing test now properly returns exit code 1 

Among the refactorings made along the way : 
- Command tests are made in a separate bash file "cmd/test/test_commands.sh"
- Required parameters "server" and "bookingId" are checked in cobra PreRun function. 
- Endpoint type has now a property "HasPathParam". There is no endpoint in the standard covoiturage that expects more than one path parameter. 
- Guessing server and endpoint is now made in a single `SplitServerEndpoint` function.