### PR TITLE
refactor: simplify initAPIMapping() to init()

### DIFF
--- a/cmd/test/api_mapping.go
+++ b/cmd/test/api_mapping.go
@@ -14,9 +14,6 @@ var apiMapping = map[Endpoint]ResponseTestFun{}
 // GetAPIMapping returns the mapping between endpoint and the associated test
 // function
 func GetAPIMapping() map[Endpoint]ResponseTestFun {
-	if len(apiMapping) == 0 {
-		initAPIMapping()
-	}
 	return apiMapping
 }
 

--- a/cmd/test/test_exported.go
+++ b/cmd/test/test_exported.go
@@ -2,8 +2,7 @@ package test
 
 import "net/http"
 
-// initAPIMapping associates every available test to a given endpoint
-func initAPIMapping() {
+func init() {
 	// Tag "Search"
 
 	Register(TestGetDriverJourneysResponse, GetDriverJourneysEndpoint)


### PR DESCRIPTION
Golang init() function is automatically run before the main function. So there is no need to call it manually when the mapping is fetched. 