### PR TITLE
feat: support authentication with X-API-Key header

### DIFF
--- a/cmd/get_bookings.go
+++ b/cmd/get_bookings.go
@@ -18,7 +18,8 @@ func init() {
 
 	getBookingsCmd.Run = func(cmd *cobra.Command, args []string) {
 		URL, _ := url.JoinPath(server, "/bookings", getBookingID)
-		err := test.RunTest(http.MethodGet, URL, verbose, test.NewQuery(), nil, flags(http.StatusOK))
+		err := test.RunTest(http.MethodGet, URL, verbose, test.NewQuery(), nil,
+			apiKey, flags(http.StatusOK))
 		exitWithError(err)
 	}
 

--- a/cmd/get_driver_journeys.go
+++ b/cmd/get_driver_journeys.go
@@ -29,7 +29,7 @@ func init() {
 	driverJourneysCmd.Run = func(cmd *cobra.Command, args []string) {
 		query := makeJourneyQuery(departureLat, departureLng, arrivalLat, arrivalLng, departureDate, timeDelta, departureRadius, arrivalRadius, count)
 		URL, _ := url.JoinPath(server, "/driver_journeys")
-		err := test.RunTest(http.MethodGet, URL, verbose, query, nil, flags(http.StatusOK))
+		err := test.RunTest(http.MethodGet, URL, verbose, query, nil, apiKey, flags(http.StatusOK))
 		exitWithError(err)
 	}
 

--- a/cmd/get_driver_regular_trips.go
+++ b/cmd/get_driver_regular_trips.go
@@ -73,7 +73,7 @@ func getDriverRegularTripsRun(
 	)
 	URL, _ := url.JoinPath(server, "/driver_regular_trips")
 
-	return runner.Run(http.MethodGet, URL, verbose, query, nil, flags(http.StatusOK))
+	return runner.Run(http.MethodGet, URL, verbose, query, nil, apiKey, flags(http.StatusOK))
 }
 
 func makeRegularTripQuery(

--- a/cmd/get_passenger_journeys.go
+++ b/cmd/get_passenger_journeys.go
@@ -18,7 +18,7 @@ func init() {
 			timeDelta, departureRadius, arrivalRadius, count,
 		)
 		URL, _ := url.JoinPath(server, "/passenger_journeys")
-		err := test.RunTest(http.MethodGet, URL, verbose, query, nil, flags(http.StatusOK))
+		err := test.RunTest(http.MethodGet, URL, verbose, query, nil, apiKey, flags(http.StatusOK))
 		exitWithError(err)
 	}
 

--- a/cmd/get_passenger_regular_trips.go
+++ b/cmd/get_passenger_regular_trips.go
@@ -67,5 +67,5 @@ func getPassengerRegularTripsRun(
 	)
 	URL, _ := url.JoinPath(server, "/passenger_regular_trips")
 
-	return runner.Run(http.MethodGet, URL, verbose, query, nil, flags(http.StatusOK))
+	return runner.Run(http.MethodGet, URL, verbose, query, nil, apiKey, flags(http.StatusOK))
 }

--- a/cmd/get_status.go
+++ b/cmd/get_status.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/fabmob/playground-standard-covoiturage/cmd/test"
+	"github.com/spf13/cobra"
+)
+
+var statusCmd = makeEndpointCommand(test.GetStatusEndpoint)
+
+func init() {
+
+	statusCmd.Run = func(cmd *cobra.Command, args []string) {
+		URL, _ := url.JoinPath(server, "/status")
+		err := test.RunTest(http.MethodGet, URL, verbose, test.NewQuery(), nil, apiKey, flags(http.StatusOK))
+		exitWithError(err)
+	}
+
+	getCmd.AddCommand(statusCmd)
+}

--- a/cmd/patch_bookings.go
+++ b/cmd/patch_bookings.go
@@ -55,7 +55,7 @@ func patchBookingsRun(runner test.TestRunner, server, bookingID, status, message
 		return err
 	}
 
-	return runner.Run(http.MethodPatch, URL, verbose, query, nil, flags(http.StatusOK))
+	return runner.Run(http.MethodPatch, URL, verbose, query, nil, apiKey, flags(http.StatusOK))
 }
 
 func checkPatchBookingsCmdFlags(cmd *cobra.Command, args []string) error {

--- a/cmd/post_booking_events.go
+++ b/cmd/post_booking_events.go
@@ -36,6 +36,5 @@ func postBookingEventsRun(runner test.TestRunner, server string, body []byte) er
 		return err
 	}
 
-	return runner.Run(http.MethodPost, URL, verbose, query, body,
-		flags(http.StatusOK))
+	return runner.Run(http.MethodPost, URL, verbose, query, body, apiKey, flags(http.StatusOK))
 }

--- a/cmd/post_bookings.go
+++ b/cmd/post_bookings.go
@@ -19,7 +19,7 @@ func init() {
 		exitWithError(err)
 
 		URL, _ := url.JoinPath(server, "/bookings")
-		err = test.RunTest(http.MethodPost, URL, verbose, test.NewQuery(), body, flags(http.StatusCreated))
+		err = test.RunTest(http.MethodPost, URL, verbose, test.NewQuery(), body, apiKey, flags(http.StatusCreated))
 		exitWithError(err)
 	}
 

--- a/cmd/post_messages.go
+++ b/cmd/post_messages.go
@@ -42,6 +42,7 @@ func getMessagesRun(runner test.TestRunner, server string, body []byte) error {
 		verbose,
 		test.NewQuery(),
 		body,
+		apiKey,
 		flags(http.StatusCreated),
 	)
 }

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -11,10 +11,17 @@ var serveCmd = &cobra.Command{
 	Short: "Serves a test API enforcing the standard covoitrage specification",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
-		service.Run()
+		if backgroundProcess {
+			go service.Run()
+		} else {
+			service.Run()
+		}
 	},
 }
 
+var backgroundProcess bool
+
 func init() {
+	serveCmd.Flags().BoolVar(&backgroundProcess, "bg", false, "Run the server in a background process")
 	rootCmd.AddCommand(serveCmd)
 }

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -11,17 +11,10 @@ var serveCmd = &cobra.Command{
 	Short: "Serves a test API enforcing the standard covoitrage specification",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
-		if backgroundProcess {
-			go service.Run()
-		} else {
-			service.Run()
-		}
+		service.Run()
 	},
 }
 
-var backgroundProcess bool
-
 func init() {
-	serveCmd.Flags().BoolVar(&backgroundProcess, "bg", false, "Run the server in a background process")
 	rootCmd.AddCommand(serveCmd)
 }

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -18,12 +18,13 @@ Cobra is a CLI library for Go that empowers applications.
 This application is a tool to generate the needed files
 to quickly create a Cobra application.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		err := test.RunTest(http.MethodGet, URL, verbose, query, nil, flags(http.StatusOK))
+		err := test.RunTest(http.MethodGet, URL, verbose, query, nil, apiKey, flags(http.StatusOK))
 		exitWithError(err)
 	},
 }
 
 var (
+	apiKey        string
 	URL           string
 	verbose       bool
 	query         test.Query
@@ -41,6 +42,7 @@ func init() {
 		test.DefaultDisallowEmptyFlag,
 		"Should an empty request return an error",
 	)
+	testCmd.PersistentFlags().StringVar(&apiKey, "auth", "", "API key sent in the \"X-API-Key\" header of the request")
 	testCmd.PersistentFlags().IntVar(
 		&expectStatus,
 		"expectStatus",

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -10,13 +10,8 @@ import (
 // testCmd represents the test command
 var testCmd = &cobra.Command{
 	Use:   "test",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+	Short: "Test an API complying with the standard covoiturage",
+	Long:  "Test an API complying with the standard covoiturage",
 	Run: func(cmd *cobra.Command, args []string) {
 		err := test.RunTest(http.MethodGet, URL, verbose, query, nil, apiKey, flags(http.StatusOK))
 		exitWithError(err)

--- a/cmd/test/api_mapping_test.go
+++ b/cmd/test/api_mapping_test.go
@@ -67,6 +67,15 @@ func TestSplitServerEndpoint(t *testing.T) {
 			GetBookingsEndpoint,
 			false,
 		},
+
+		{
+			"more complex case 4: real example",
+			http.MethodGet,
+			"https://api-host.preprod-ab.some-domain.fr/api/path/1ab2c34-56d-343e21-f0g/other_stuff/driver_journeys?departureLat=48.8588548&departureLng=2.264463&arrivalLat=47.8733876&arrivalLng=1.8296428&departureDate=1668608335&timeDelta=100000&departureRadius=10&arrivalRadius=10",
+			"https://api-host.preprod-ab.some-domain.fr/api/path/1ab2c34-56d-343e21-f0g/other_stuff",
+			GetDriverJourneysEndpoint,
+			false,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -20,9 +20,9 @@ func NewDefaultRunner() *DefaultRunner {
 // Run runs the cli validation and returns an exit code
 func (*DefaultRunner) Run(method, URL string, verbose bool, query Query, body []byte, apiKey string, flags Flags) error {
 
-	req, err := http.NewRequest(method, URL, nil)
+	req, err := makeRequest(method, URL, body, apiKey)
 	if err != nil {
-		return err
+		return nil
 	}
 
 	AddQueryParameters(query, req)
@@ -45,4 +45,8 @@ func (*DefaultRunner) Run(method, URL string, verbose bool, query Query, body []
 func RunTest(method, URL string, verbose bool, query Query, body []byte, apiKey string, flags Flags) error {
 	runner := DefaultRunner{}
 	return runner.Run(method, URL, verbose, query, body, apiKey, flags)
+}
+
+func makeRequest(method, URL string, body []byte, apiKey string) (*http.Request, error) {
+	return http.NewRequest(method, URL, nil)
 }

--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -23,6 +23,7 @@ func (*DefaultRunner) Run(method, URL string, verbose bool, query Query, body []
 	if err != nil {
 		return nil
 	}
+	fmt.Println(req)
 
 	AddQueryParameters(query, req)
 

--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 type TestRunner interface {
-	Run(method, URL string, verbose bool, query Query, body []byte, flags Flags) error
+	Run(method, URL string, verbose bool, query Query, body []byte, apiKey string, flags Flags) error
 }
 
 type DefaultRunner struct{}
@@ -18,7 +18,7 @@ func NewDefaultRunner() *DefaultRunner {
 }
 
 // Run runs the cli validation and returns an exit code
-func (*DefaultRunner) Run(method, URL string, verbose bool, query Query, body []byte, flags Flags) error {
+func (*DefaultRunner) Run(method, URL string, verbose bool, query Query, body []byte, apiKey string, flags Flags) error {
 
 	req, err := http.NewRequest(method, URL, nil)
 	if err != nil {
@@ -42,7 +42,7 @@ func (*DefaultRunner) Run(method, URL string, verbose bool, query Query, body []
 	return nil
 }
 
-func RunTest(method, URL string, verbose bool, query Query, body []byte, flags Flags) error {
+func RunTest(method, URL string, verbose bool, query Query, body []byte, apiKey string, flags Flags) error {
 	runner := DefaultRunner{}
-	return runner.Run(method, URL, verbose, query, body, flags)
+	return runner.Run(method, URL, verbose, query, body, apiKey, flags)
 }

--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"fmt"
-	"net/http"
 
 	"github.com/pkg/errors"
 )
@@ -45,16 +44,4 @@ func (*DefaultRunner) Run(method, URL string, verbose bool, query Query, body []
 func RunTest(method, URL string, verbose bool, query Query, body []byte, apiKey string, flags Flags) error {
 	runner := DefaultRunner{}
 	return runner.Run(method, URL, verbose, query, body, apiKey, flags)
-}
-
-const authentificationHeader = "X-API-Key"
-
-func makeRequest(method, URL string, body []byte, apiKey string) (*http.Request, error) {
-	req, err := http.NewRequest(method, URL, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Set(authentificationHeader, apiKey)
-	return req, err
 }

--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -19,7 +19,7 @@ func (*DefaultRunner) Run(method, URL string, verbose bool, query Query, body []
 
 	req, err := makeRequest(method, URL, body, apiKey)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	AddQueryParameters(query, req)

--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -23,7 +23,6 @@ func (*DefaultRunner) Run(method, URL string, verbose bool, query Query, body []
 	if err != nil {
 		return nil
 	}
-	fmt.Println(req)
 
 	AddQueryParameters(query, req)
 

--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -47,6 +47,14 @@ func RunTest(method, URL string, verbose bool, query Query, body []byte, apiKey 
 	return runner.Run(method, URL, verbose, query, body, apiKey, flags)
 }
 
+const authentificationHeader = "X-API-Key"
+
 func makeRequest(method, URL string, body []byte, apiKey string) (*http.Request, error) {
-	return http.NewRequest(method, URL, nil)
+	req, err := http.NewRequest(method, URL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set(authentificationHeader, apiKey)
+	return req, err
 }

--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -2,8 +2,6 @@ package test
 
 import (
 	"fmt"
-
-	"github.com/pkg/errors"
 )
 
 type TestRunner interface {
@@ -35,7 +33,7 @@ func (*DefaultRunner) Run(method, URL string, verbose bool, query Query, body []
 	fmt.Println(report)
 
 	if report.hasErrors() {
-		return errors.New(report.String())
+		return fmt.Errorf("❌ %d failed assertion(s) ", report.countErrors())
 	}
 
 	return nil

--- a/cmd/test/request.go
+++ b/cmd/test/request.go
@@ -6,6 +6,18 @@ import (
 	"strings"
 )
 
+const authentificationHeader = "X-API-Key"
+
+func makeRequest(method, URL string, body []byte, apiKey string) (*http.Request, error) {
+	req, err := http.NewRequest(method, URL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set(authentificationHeader, apiKey)
+	return req, err
+}
+
 // Query implements flag.Value interface to store query parameters
 type Query struct {
 	Params map[string]string

--- a/cmd/test/request_test.go
+++ b/cmd/test/request_test.go
@@ -1,0 +1,29 @@
+package test
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestMakeRequestHeader(t *testing.T) {
+	var (
+		method        = http.MethodGet
+		URL           = "http://localhost:9999"
+		body   []byte = nil
+	)
+
+	testCases := []string{
+		"1234",
+		"4567",
+	}
+
+	for _, apiKey := range testCases {
+		req, err := makeRequest(method, URL, body, apiKey)
+		panicIf(err)
+
+		if req.Header.Get("X-API-Key") != apiKey {
+			t.Error("X-API-Key header is not specified properly")
+		}
+	}
+
+}

--- a/cmd/test/testing.go
+++ b/cmd/test/testing.go
@@ -231,6 +231,7 @@ type MockRunner struct {
 	Verbose bool
 	Query   Query
 	Body    []byte
+	APIKey  string
 	Flags   Flags
 }
 
@@ -241,6 +242,7 @@ func (mr *MockRunner) Run(
 	verbose bool,
 	query Query,
 	body []byte,
+	apiKey string,
 	flags Flags,
 ) error {
 
@@ -249,6 +251,7 @@ func (mr *MockRunner) Run(
 	mr.Verbose = verbose
 	mr.Query = query
 	mr.Body = body
+	mr.APIKey = apiKey
 	mr.Flags = flags
 
 	return nil


### PR DESCRIPTION
Token that should populate the "X-API-Key" is provided through the --auth flag. 

Things that should have been in their own PR:
- Add `test get status` command, which was missing.  

Among the refactorings : 
- Fix the bug that report was printed twice when there was an error (once to stdout and once to stderr).
