### PR TITLE
fix: CI checks that the server is up before running the tests

### DIFF
--- a/.github/workflows/go_tests_lint.yml
+++ b/.github/workflows/go_tests_lint.yml
@@ -43,14 +43,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - name: Setup go 1.19
         uses: actions/setup-go@v3
         with:
           go-version: 1.19
+
       - name: run server
         run: go run main.go serve &
-      - name: wait for server
-        run: sleep 2
+
+      - name: check server
+        run: timeout 10s bash -c 'until [ $(curl --output /dev/null --silent --fail --write-out "%{http_code}" "http://localhost:1323") -ne "000" ]; do printf "."; sleep 1; done;'
+
       - name: test commands
         run: bash cmd/test/test_commands.sh
 

--- a/.github/workflows/go_tests_lint.yml
+++ b/.github/workflows/go_tests_lint.yml
@@ -53,7 +53,7 @@ jobs:
         run: go run main.go serve &
 
       - name: check server
-        run: timeout 10s bash -c 'until [ $(curl --output /dev/null --silent --fail --write-out "%{http_code}" "http://localhost:1323") -ne "000" ]; do printf "."; sleep 1; done;'
+        run: timeout 30s bash -c 'until [ $(curl --output /dev/null --silent --fail --write-out "%{http_code}" "http://localhost:1323") -ne "000" ]; do printf "."; sleep 1; done;'
 
       - name: test commands
         run: bash cmd/test/test_commands.sh


### PR DESCRIPTION
Fixes #18 

Adds a "check server" step after the server is launched in background, that waits until `curl http://localhost:1323` gets a response, or timeouts after 30 seconds.