### PR TITLE
feat: Implement POST /messages

### DIFF
--- a/cmd/service/api.go
+++ b/cmd/service/api.go
@@ -200,8 +200,7 @@ func (*StdCovServerImpl) GetDriverRegularTrips(
 // PostMessages sends a mesage to the owner of a retrieved journey.
 // (POST /messages)
 func (*StdCovServerImpl) PostMessages(ctx echo.Context) error {
-	// Implement me
-	return nil
+	return ctx.NoContent(http.StatusCreated)
 }
 
 // GetPassengerJourneys searches for matching punctual planned outward pasenger journeys.

--- a/cmd/service/api.go
+++ b/cmd/service/api.go
@@ -210,7 +210,7 @@ func (s *StdCovServerImpl) PostMessages(ctx echo.Context) error {
 	}
 
 	if !userExists(message.To, users) {
-		return ctx.JSON(http.StatusNotFound, errorBody(errors.New("missing_user: recipient")))
+		return ctx.JSON(http.StatusNotFound, errorBody(errors.New("missing_user")))
 	}
 
 	return ctx.NoContent(http.StatusCreated)

--- a/cmd/service/api.go
+++ b/cmd/service/api.go
@@ -199,7 +199,20 @@ func (*StdCovServerImpl) GetDriverRegularTrips(
 
 // PostMessages sends a mesage to the owner of a retrieved journey.
 // (POST /messages)
-func (*StdCovServerImpl) PostMessages(ctx echo.Context) error {
+func (s *StdCovServerImpl) PostMessages(ctx echo.Context) error {
+	users := s.mockDB.GetUsers()
+
+	var message api.PostMessagesJSONBody
+
+	bodyUnmarshallingErr := ctx.Bind(&message)
+	if bodyUnmarshallingErr != nil {
+		return ctx.JSON(http.StatusBadRequest, errorBody(bodyUnmarshallingErr))
+	}
+
+	if !userExists(message.To, users) {
+		return ctx.JSON(http.StatusNotFound, errorBody(errors.New("missing_user: recipient")))
+	}
+
 	return ctx.NoContent(http.StatusCreated)
 }
 

--- a/cmd/service/api.go
+++ b/cmd/service/api.go
@@ -213,6 +213,8 @@ func (s *StdCovServerImpl) PostMessages(ctx echo.Context) error {
 		return ctx.JSON(http.StatusNotFound, errorBody(errors.New("missing_user")))
 	}
 
+	s.mockDB.Messages = append(s.mockDB.Messages, message)
+
 	return ctx.NoContent(http.StatusCreated)
 }
 

--- a/cmd/service/api_test.go
+++ b/cmd/service/api_test.go
@@ -633,7 +633,6 @@ func TestPostMessage(t *testing.T) {
 		flags.ExpectedStatusCode = tc.expectedStatusCode
 
 		testPostMessageHelper(t, mockDB, tc.message, flags)
-
 	}
 }
 

--- a/cmd/service/api_test.go
+++ b/cmd/service/api_test.go
@@ -616,13 +616,14 @@ func TestPostBookingEvents(t *testing.T) {
 }
 
 func TestPostMessage(t *testing.T) {
+	bob := api.User{Id: "1", Alias: "bob"}
+	alice := api.User{Id: "2", Alias: "alice"}
 	testCases := []struct {
 		message            api.PostMessagesJSONBody
 		expectedStatusCode int
 	}{
 		{
-			makeMessage(api.User{Id: "1", Alias: "quidam1"}, api.User{Id: "2",
-				Alias: "quidam2"}),
+			makeMessage(bob, alice),
 			http.StatusCreated,
 		},
 	}

--- a/cmd/service/api_test.go
+++ b/cmd/service/api_test.go
@@ -644,6 +644,7 @@ func TestPostMessage(t *testing.T) {
 			http.StatusCreated,
 		},
 	}
+
 	for _, tc := range testCases {
 		mockDB := NewMockDB()
 		mockDB.Users = tc.existingUsers

--- a/cmd/service/api_test.go
+++ b/cmd/service/api_test.go
@@ -614,6 +614,47 @@ func TestPostBookingEvents(t *testing.T) {
 	}
 }
 
+func TestPostMessage(t *testing.T) {
+	testCases := []struct {
+		message            api.PostMessagesJSONBody
+		expectedStatusCode int
+	}{
+		{
+			makeMessage(api.User{Id: "1", Alias: "quidam1"}, api.User{Id: "2",
+				Alias: "quidam2"}),
+			http.StatusOK,
+		},
+	}
+	for _, tc := range testCases {
+		mockDB := NewMockDB()
+
+		flags := test.NewFlags()
+		flags.ExpectedStatusCode = tc.expectedStatusCode
+
+		testPostMessageHelper(t, mockDB, tc.message, flags)
+
+	}
+}
+
+func testPostMessageHelper(t *testing.T, mockDB *MockDB, message api.PostMessagesJSONBody, flags test.Flags) {
+	request, err := api.NewPostMessagesRequest(fakeServer,
+		api.PostMessagesJSONRequestBody(message))
+	panicIf(err)
+
+	// Setup testing server with response recorder
+	handler, ctx, rec := setupTestServer(mockDB, request)
+
+	// Make API Call
+	err = handler.PostMessages(ctx)
+	panicIf(err)
+
+	// Test response
+	response := rec.Result()
+
+	assertionResults := test.TestPostMessagesResponse(request, response, flags)
+	checkAssertionResults(t, assertionResults)
+}
+
 func testPostBookingEventsHelper(t *testing.T, mockDB *MockDB,
 	carpoolBookingEvent *api.CarpoolBookingEvent, flags test.Flags) {
 

--- a/cmd/service/api_test.go
+++ b/cmd/service/api_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -622,7 +623,7 @@ func TestPostMessage(t *testing.T) {
 		{
 			makeMessage(api.User{Id: "1", Alias: "quidam1"}, api.User{Id: "2",
 				Alias: "quidam2"}),
-			http.StatusOK,
+			http.StatusCreated,
 		},
 	}
 	for _, tc := range testCases {
@@ -650,6 +651,7 @@ func testPostMessageHelper(t *testing.T, mockDB *MockDB, message api.PostMessage
 
 	// Test response
 	response := rec.Result()
+	fmt.Println(response)
 
 	assertionResults := test.TestPostMessagesResponse(request, response, flags)
 	checkAssertionResults(t, assertionResults)

--- a/cmd/service/api_test.go
+++ b/cmd/service/api_test.go
@@ -616,8 +616,11 @@ func TestPostBookingEvents(t *testing.T) {
 }
 
 func TestPostMessage(t *testing.T) {
-	bob := api.User{Id: "1", Alias: "bob"}
-	alice := api.User{Id: "2", Alias: "alice"}
+	var (
+		bob   = makeUser("1", "bob")
+		alice = makeUser("2", "alice")
+	)
+
 	testCases := []struct {
 		message            api.PostMessagesJSONBody
 		existingUsers      []api.User
@@ -627,6 +630,12 @@ func TestPostMessage(t *testing.T) {
 			makeMessage(bob, alice),
 			[]api.User{bob, alice},
 			http.StatusCreated,
+		},
+
+		{
+			makeMessage(bob, alice),
+			[]api.User{bob},
+			http.StatusNotFound,
 		},
 	}
 	for _, tc := range testCases {

--- a/cmd/service/api_test.go
+++ b/cmd/service/api_test.go
@@ -637,6 +637,12 @@ func TestPostMessage(t *testing.T) {
 			[]api.User{bob},
 			http.StatusNotFound,
 		},
+
+		{
+			makeMessage(bob, alice),
+			[]api.User{alice},
+			http.StatusCreated,
+		},
 	}
 	for _, tc := range testCases {
 		mockDB := NewMockDB()

--- a/cmd/service/api_test.go
+++ b/cmd/service/api_test.go
@@ -620,15 +620,18 @@ func TestPostMessage(t *testing.T) {
 	alice := api.User{Id: "2", Alias: "alice"}
 	testCases := []struct {
 		message            api.PostMessagesJSONBody
+		existingUsers      []api.User
 		expectedStatusCode int
 	}{
 		{
 			makeMessage(bob, alice),
+			[]api.User{bob, alice},
 			http.StatusCreated,
 		},
 	}
 	for _, tc := range testCases {
 		mockDB := NewMockDB()
+		mockDB.Users = tc.existingUsers
 
 		flags := test.NewFlags()
 		flags.ExpectedStatusCode = tc.expectedStatusCode

--- a/cmd/service/data.go
+++ b/cmd/service/data.go
@@ -55,6 +55,14 @@ func (m *MockDB) GetBookings() BookingsByID {
 	return m.Bookings
 }
 
+func (m *MockDB) GetUsers() []api.User {
+	if m.Users == nil {
+		m.Users = []api.User{}
+	}
+
+	return m.Users
+}
+
 func (m *MockDB) GetBooking(bookingID uuid.UUID) (*api.Booking, error) {
 	bookings := m.GetBookings()
 

--- a/cmd/service/data.go
+++ b/cmd/service/data.go
@@ -15,10 +15,11 @@ import (
 
 // MockDB stores the data of the server in memory
 type MockDB struct {
-	DriverJourneys    []api.DriverJourney    `json:"driverJourneys"`
-	PassengerJourneys []api.PassengerJourney `json:"passengerJourneys"`
-	Bookings          BookingsByID           `json:"bookings"`
-	Users             []api.User             `json:"users"`
+	DriverJourneys    []api.DriverJourney        `json:"driverJourneys"`
+	PassengerJourneys []api.PassengerJourney     `json:"passengerJourneys"`
+	Bookings          BookingsByID               `json:"bookings"`
+	Users             []api.User                 `json:"users"`
+	Messages          []api.PostMessagesJSONBody `json:"messages"`
 }
 
 // NewMockDB initiates a MockDB with no data

--- a/cmd/service/data.go
+++ b/cmd/service/data.go
@@ -18,6 +18,7 @@ type MockDB struct {
 	DriverJourneys    []api.DriverJourney    `json:"driverJourneys"`
 	PassengerJourneys []api.PassengerJourney `json:"passengerJourneys"`
 	Bookings          BookingsByID           `json:"bookings"`
+	Users             []api.User             `json:"users"`
 }
 
 // NewMockDB initiates a MockDB with no data

--- a/cmd/service/helpers.go
+++ b/cmd/service/helpers.go
@@ -53,3 +53,14 @@ func errorBody(err error) api.BadRequest {
 	errStr := err.Error()
 	return api.BadRequest{Error: &errStr}
 }
+
+func userExists(user api.User, users []api.User) bool {
+	for _, existingUser := range users {
+		if existingUser.Id == user.Id &&
+			existingUser.Operator == user.Operator {
+			return true
+		}
+	}
+
+	return false
+}

--- a/cmd/service/testing.go
+++ b/cmd/service/testing.go
@@ -176,6 +176,19 @@ func makeMessage(from api.User, to api.User) api.PostMessagesJSONBody {
 	}
 }
 
+func makeUser(id, alias string) api.User {
+	defaultOperator := "default.operator.com"
+	return makeUserWithOperator(id, alias, defaultOperator)
+}
+
+func makeUserWithOperator(id, alias, operator string) api.User {
+	return api.User{
+		Id:       id,
+		Alias:    alias,
+		Operator: operator,
+	}
+}
+
 // repUUID creates a reproducible UUID
 func repUUID(seed int64) uuid.UUID {
 	// generate random bytes

--- a/cmd/service/testing.go
+++ b/cmd/service/testing.go
@@ -167,6 +167,15 @@ func makeCarpoolBookingEventWithStatus(eventID, bookingID uuid.UUID, status api.
 	return carpoolBookingEvent
 }
 
+func makeMessage(from api.User, to api.User) api.PostMessagesJSONBody {
+	return api.PostMessagesJSONBody{
+		From:                   from,
+		To:                     to,
+		Message:                "some message",
+		RecipientCarpoolerType: "DRIVER",
+	}
+}
+
 // repUUID creates a reproducible UUID
 func repUUID(seed int64) uuid.UUID {
 	// generate random bytes


### PR DESCRIPTION
Implements POST /messages endpoint. 

Recipient user must exist to be able to send a message (404 code otherwise). 
Currently, messages are stored, but there is no way of retrieving them. 