### PR TITLE
doc: package documentations

### DIFF
--- a/cmd/api/gogen.go
+++ b/cmd/api/gogen.go
@@ -1,3 +1,8 @@
+// Package api has helper functions to manipulate operations linked to the api
+// specification.
+//
+// Most of the functions are generated from the OpenAPI specfication with
+// oapi-codegen
 package api
 
 //go:generate oapi-codegen -config oapi-codegen-config.yaml ../../spec/stdcov_openapi.yaml

--- a/cmd/service/db/db.go
+++ b/cmd/service/db/db.go
@@ -1,3 +1,11 @@
+// Package db  handles data storage and manipulation for the API server.
+//
+// It exports type `Mock` used to store data in memory, but it can be replaced
+// with another storage with the interface `DB` (which `Mock` implements).
+//
+// A MockDB can be initialized with data, given the data is in json format as
+// expected by `MockDBDataInterface`. It can also write its data in json
+// format (through the same `MockDBDataInterface`) with the function `WriteData`.
 package db
 
 import (
@@ -116,7 +124,7 @@ func (err MissingBookingErr) Error() string {
 // MockDB from data
 //////////////////////////////////////////////////////////
 
-type mockDBDataInterface struct {
+type MockDBDataInterface struct {
 	DriverJourneys    []api.DriverJourney        `json:"driverJourneys"`
 	PassengerJourneys []api.PassengerJourney     `json:"passengerJourneys"`
 	Bookings          []*api.Booking             `json:"bookings"`
@@ -124,8 +132,8 @@ type mockDBDataInterface struct {
 	Messages          []api.PostMessagesJSONBody `json:"messages"`
 }
 
-func toOutputData(m *Mock) mockDBDataInterface {
-	outputData := mockDBDataInterface{}
+func toOutputData(m *Mock) MockDBDataInterface {
+	outputData := MockDBDataInterface{}
 
 	outputData.DriverJourneys = m.DriverJourneys
 	outputData.PassengerJourneys = m.PassengerJourneys
@@ -157,7 +165,7 @@ func WriteData(m *Mock, w io.Writer) error {
 	return nil
 }
 
-func fromInputData(inputData mockDBDataInterface) *Mock {
+func fromInputData(inputData MockDBDataInterface) *Mock {
 	var m = NewMockDB()
 
 	m.DriverJourneys = inputData.DriverJourneys
@@ -181,7 +189,7 @@ func NewMockDBWithDefaultData() *Mock {
 // NewMockDBWithData reads journey data from io.Reader with json data.
 // It does not validate data against the standard.
 func NewMockDBWithData(r io.Reader) (*Mock, error) {
-	var data mockDBDataInterface
+	var data MockDBDataInterface
 
 	bytes, readErr := io.ReadAll(r)
 	if readErr != nil {

--- a/cmd/service/db/db_test.go
+++ b/cmd/service/db/db_test.go
@@ -69,7 +69,7 @@ func TestNewMockDBWithData(t *testing.T) {
 	var (
 		b bytes.Buffer
 
-		data = mockDBDataInterface{}
+		data = MockDBDataInterface{}
 
 		id      = uuid.New()
 		booking = api.Booking{Id: id}

--- a/cmd/service/main.go
+++ b/cmd/service/main.go
@@ -1,3 +1,10 @@
+// Package service serves a fake API complying with standard covoiturage
+// specification.
+//
+// The server is launched wih the `Run` function, which optionally accepts the
+// path to a data file (json format). See Package db documentation for more
+// information about the data format. If an empty path is provided, then
+// default data is loaded.
 package service
 
 import (

--- a/cmd/test/main.go
+++ b/cmd/test/main.go
@@ -1,3 +1,17 @@
+// Package test has all utilities to perform a test on an endpoint of
+// Standard-Covoiturage.
+//
+// Function `Run` runs adequate tests against a request to the standard
+// covoiturage, detailed with method,
+// URL, query and body.
+//
+// Test functions specific to a given endpoint are exported as
+// `Test{Method}{Path}Response` functions (all camel case).
+//
+// The expectations of the tests can be refined thanks to the test `Flags`.
+//
+// `Assert*` functions are atomic assertions used in tests that can be extended through the
+// `Assertion` interface.
 package test
 
 import (

--- a/cmd/util/testing.go
+++ b/cmd/util/testing.go
@@ -1,3 +1,6 @@
+// Package util exports some utility functions, that have no dependency to
+// other packages of this module, and that may be used in other
+// packages.
 package util
 
 // PanicIf panics if there is an error. Use for testing purposes only.


### PR DESCRIPTION
Adds godoc comments to all packages of the module.

+ following modification : 

* Exports `MockDBDataInterface` so that it can document the expected data format when reading or writing data from a MockDB. 