### PR TITLE
fix: dev release

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,7 +4,6 @@ project_name: pscovoit
 before:
   hooks:
     - go mod tidy
-    - go generate ./...
 builds:
   - env:
       - CGO_ENABLED=0

--- a/cmd/service/testing.go
+++ b/cmd/service/testing.go
@@ -428,13 +428,14 @@ func requestAll(t *testing.T, driverOrPassenger string) api.GetJourneysParams {
 	t.Helper()
 
 	var (
-		largeTimeDelta = int(1e10)
+		largeTimeDelta = int(1e9)
 		largeRadius    = float32(1e6)
 	)
 
 	switch driverOrPassenger {
 	case "driver":
 		params := api.GetDriverJourneysParams{}
+		params.DepartureDate = 1e9
 		params.TimeDelta = &largeTimeDelta
 		params.DepartureRadius = &largeRadius
 		params.ArrivalRadius = &largeRadius
@@ -443,6 +444,7 @@ func requestAll(t *testing.T, driverOrPassenger string) api.GetJourneysParams {
 
 	case "passenger":
 		params := api.GetPassengerJourneysParams{}
+		params.DepartureDate = 1e9
 		params.TimeDelta = &largeTimeDelta
 		params.DepartureRadius = &largeRadius
 		params.ArrivalRadius = &largeRadius

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/labstack/echo/v4 v4.9.1
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.6.1
+	github.com/spf13/pflag v1.0.5
 	github.com/stoewer/go-strcase v1.2.0
 	github.com/stretchr/testify v1.8.1
 	github.com/umahmood/haversine v0.0.0-20151105152445-808ab04add26
@@ -31,7 +32,6 @@ require (
 	github.com/mattn/go-isatty v0.0.16 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
 	golang.org/x/crypto v0.1.0 // indirect


### PR DESCRIPTION
Fix two issues with goreleaser : 

* go generate changes the order of data (because it uses maps which are unordered in golang) and puts git in a dirty state. 
* The integer 1e10 does not fit in every x32 architectures, changed to 1e9 which should be fine. 