### PR TITLE
feat: generated example test commands for GET /driver_journeys and GET /passenger_journeys

### DIFF
--- a/cmd/service/api_test.go
+++ b/cmd/service/api_test.go
@@ -723,6 +723,29 @@ func TestPostMessage(t *testing.T) {
 	}
 }
 
+// Should be kept after tests that requires generation as it relies on order of execution of tests.
+func TestGeneration(t *testing.T) {
+	if generateTestData {
+
+		var b bytes.Buffer
+
+		err := db.WriteData(generatedData, &b)
+		util.PanicIf(err)
+
+		bytes, err := io.ReadAll(&b)
+		util.PanicIf(err)
+
+		err = os.WriteFile(generatedTestDataFile, bytes, 0644)
+		util.PanicIf(err)
+
+		err = os.WriteFile(generatedTestCommandsFile, []byte(commandsFile.String()), 0644)
+		util.PanicIf(err)
+	}
+	generateTestData = false
+}
+
+// after this, no test is generated
+
 func TestDefaultDriverJourneysValidity(t *testing.T) {
 	params := requestAll(t, "driver")
 	mockDB := db.NewMockDBWithDefaultData()
@@ -751,24 +774,4 @@ func TestDefaultPassengerJourneysValidity(t *testing.T) {
 		params.(*api.GetPassengerJourneysParams),
 		flags,
 	)
-}
-
-// Should be kept at the end as it relies on order of execution of tests.
-func TestGeneration(t *testing.T) {
-	if generateTestData {
-
-		var b bytes.Buffer
-
-		err := db.WriteData(generatedData, &b)
-		util.PanicIf(err)
-
-		bytes, err := io.ReadAll(&b)
-		util.PanicIf(err)
-
-		err = os.WriteFile(generatedTestDataFile, bytes, 0644)
-		util.PanicIf(err)
-
-		err = os.WriteFile(generatedTestCommandsFile, []byte(commandsFile.String()), 0644)
-		util.PanicIf(err)
-	}
 }

--- a/cmd/service/api_test.go
+++ b/cmd/service/api_test.go
@@ -190,7 +190,7 @@ func TestDriverJourneys(t *testing.T) {
 					setJourneyDatesForGeneration(&tc.testData[i].JourneySchedule)
 				}
 
-				setParamDatesForGeneration(tc.testParams.(*api.GetDriverJourneysParams))
+				setParamDatesForGeneration(tc.testParams)
 			}
 
 			mockDB := db.NewMockDB()
@@ -379,7 +379,7 @@ func TestPassengerJourneys(t *testing.T) {
 					setJourneyDatesForGeneration(&tc.testData[i].JourneySchedule)
 				}
 
-				setParamDatesForGeneration(tc.testParams.(*api.GetPassengerJourneysParams))
+				setParamDatesForGeneration(tc.testParams)
 			}
 
 			mockDB := db.NewMockDB()

--- a/cmd/service/api_test.go
+++ b/cmd/service/api_test.go
@@ -182,16 +182,29 @@ func TestDriverJourneys(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 
+			// If data is generated, then the test data and the requests date
+			// properties are shifted, so that there are no two tests falling the
+			// same week. The aim is to isolate the tests.
+			if generateTestData {
+				shiftToNextWeek()
+
+				for i := range tc.testData {
+					setDatesForGeneration(&tc.testData[i])
+				}
+
+				setParamDatesForGeneration(tc.testParams.(*api.GetDriverJourneysParams))
+			}
+
 			mockDB := db.NewMockDB()
 			mockDB.DriverJourneys = tc.testData
 
 			flags := test.NewFlags()
 			flags.ExpectNonEmpty = tc.expectNonEmptyResult
 
-			testGetDriverJourneyHelper(
+			TestGetDriverJourneysHelper(
 				t,
-				tc.testParams,
 				mockDB,
+				tc.testParams.(*api.GetDriverJourneysParams),
 				flags,
 			)
 		})

--- a/cmd/service/api_test.go
+++ b/cmd/service/api_test.go
@@ -189,7 +189,7 @@ func TestDriverJourneys(t *testing.T) {
 				shiftToNextWeek()
 
 				for i := range tc.testData {
-					setDatesForGeneration(&tc.testData[i])
+					setJourneyDatesForGeneration(&tc.testData[i].JourneySchedule)
 				}
 
 				setParamDatesForGeneration(tc.testParams.(*api.GetDriverJourneysParams))
@@ -209,17 +209,6 @@ func TestDriverJourneys(t *testing.T) {
 			)
 		})
 	}
-}
-
-func testGetDriverJourneyHelper(
-	t *testing.T,
-	params api.GetJourneysParams,
-	mockDB *db.Mock,
-	flags test.Flags,
-) {
-	testFunction := test.TestGetDriverJourneysResponse
-
-	testGetJourneysHelper(t, params, mockDB, testFunction, flags)
 }
 
 func TestPassengerJourneys(t *testing.T) {
@@ -381,16 +370,30 @@ func TestPassengerJourneys(t *testing.T) {
 	for _, tc := range testCases {
 
 		t.Run(tc.name, func(t *testing.T) {
+
+			// If data is generated, then the test data and the requests date
+			// properties are shifted, so that there are no two tests falling the
+			// same week. The aim is to isolate the tests.
+			if generateTestData {
+				shiftToNextWeek()
+
+				for i := range tc.testData {
+					setJourneyDatesForGeneration(&tc.testData[i].JourneySchedule)
+				}
+
+				setParamDatesForGeneration(tc.testParams.(*api.GetPassengerJourneysParams))
+			}
+
 			mockDB := db.NewMockDB()
 			mockDB.PassengerJourneys = tc.testData
 
 			flags := test.NewFlags()
 			flags.ExpectNonEmpty = tc.expectNonEmptyResult
 
-			testGetPassengerJourneyHelper(
+			TestGetPassengerJourneysHelper(
 				t,
-				tc.testParams,
 				mockDB,
+				tc.testParams.(*api.GetPassengerJourneysParams),
 				flags,
 			)
 		})

--- a/cmd/service/api_test.go
+++ b/cmd/service/api_test.go
@@ -403,7 +403,7 @@ func TestGetBookings(t *testing.T) {
 		name               string
 		bookings           db.BookingsByID
 		queryBookingID     uuid.UUID
-		disallowEmpty      bool
+		expectNonEmpty     bool
 		expectedStatusCode int
 	}{
 		{
@@ -441,7 +441,7 @@ func TestGetBookings(t *testing.T) {
 			mockDB.Bookings = tc.bookings
 
 			flags := test.NewFlags()
-			flags.ExpectNonEmpty = tc.disallowEmpty
+			flags.ExpectNonEmpty = tc.expectNonEmpty
 			flags.ExpectedResponseCode = tc.expectedStatusCode
 
 			TestGetBookingsHelper(t, mockDB, tc.queryBookingID, flags)

--- a/cmd/service/commands_file_generation.go
+++ b/cmd/service/commands_file_generation.go
@@ -124,19 +124,23 @@ func shiftToNextWeek() {
 	unixEpochCounter += int64(weekInSeconds)
 }
 
-// setDateForGeneration sets, if `generateTestData` == true, a journey date that falls inside the week
+// setJourneyDatesForGeneration sets, if `generateTestData` == true, a journey date that falls inside the week
 // yielded by `shiftToOwnSingleWeek`
-func setDatesForGeneration(journey *api.DriverJourney) {
+func setJourneyDatesForGeneration(schedule *api.JourneySchedule) {
 	if generateTestData {
-		if journey.DriverDepartureDate != nil {
-			*journey.DriverDepartureDate += unixEpochCounter
+		if schedule.DriverDepartureDate != nil {
+			*schedule.DriverDepartureDate += unixEpochCounter
 		}
-		journey.PassengerPickupDate += unixEpochCounter
+		schedule.PassengerPickupDate += unixEpochCounter
 	}
 }
 
-func setParamDatesForGeneration(params *api.GetDriverJourneysParams) {
-	if generateTestData {
-		params.DepartureDate += int(unixEpochCounter)
+func setParamDatesForGeneration(params api.GetJourneysParams) {
+	switch p := params.(type) {
+	case *api.GetDriverJourneysParams:
+		p.DepartureDate += int(unixEpochCounter)
+
+	case *api.GetPassengerJourneysParams:
+		p.DepartureDate += int(unixEpochCounter)
 	}
 }

--- a/cmd/service/commands_file_generation.go
+++ b/cmd/service/commands_file_generation.go
@@ -92,28 +92,34 @@ func GenerateCommandStr(t *testing.T, request *http.Request, flags test.Flags, b
 	urlWithEnvVar := fmt.Sprintf("$%s%s", serverEnvVar,
 		strings.TrimPrefix(request.URL.String(), localServer))
 
+	cmd += fmt.Sprintf("echo \"%s\"\n", t.Name())
+
+	multilineCmd := []string{}
 	cmdContinuation := " \\\n  "
 
-	cmd += fmt.Sprintf("echo \"%s\"\n", t.Name())
-	cmd += "go run main.go test" + cmdContinuation +
-		fmt.Sprintf("--method=%s", request.Method) + cmdContinuation +
-		fmt.Sprintf("--url=\"%s\"", urlWithEnvVar) + cmdContinuation +
-		fmt.Sprintf("--expectResponseCode=%d", flags.ExpectedResponseCode) +
-		cmdContinuation +
-		fmt.Sprintf("--auth=\"$%s\"", authEnvVar)
+	multilineCmd = append(multilineCmd,
+		"go run main.go test",
+		fmt.Sprintf("--method=%s", request.Method),
+		fmt.Sprintf("--url=\"%s\"", urlWithEnvVar),
+		fmt.Sprintf("--expectResponseCode=%d", flags.ExpectedResponseCode),
+		fmt.Sprintf("--auth=\"$%s\"", authEnvVar),
+	)
 
 	if flags.ExpectNonEmpty {
-		cmd += cmdContinuation + "--expectNonEmpty"
+		multilineCmd = append(multilineCmd, "--expectNonEmpty")
 	}
 
 	if flags.ExpectedBookingStatus != "" {
-		cmd += cmdContinuation + fmt.Sprintf("--expectBookingStatus=%s", flags.ExpectedBookingStatus)
+		multilineCmd = append(multilineCmd,
+			fmt.Sprintf("--expectBookingStatus=%s", flags.ExpectedBookingStatus))
 	}
 
 	if body != nil {
-		cmd += cmdContinuation + fmt.Sprintf("<<< '%s'", body)
+		multilineCmd = append(multilineCmd,
+			fmt.Sprintf("<<< '%s'", body))
 	}
 
+	cmd += strings.Join(multilineCmd, cmdContinuation)
 	cmd += "\n\n"
 	return cmd
 }

--- a/cmd/service/commands_file_generation.go
+++ b/cmd/service/commands_file_generation.go
@@ -102,6 +102,10 @@ func GenerateCommandStr(t *testing.T, request *http.Request, flags test.Flags, b
 		cmdContinuation +
 		fmt.Sprintf("--auth=\"$%s\"", authEnvVar)
 
+	if flags.ExpectNonEmpty {
+		cmd += cmdContinuation + "--expectNonEmpty"
+	}
+
 	if flags.ExpectedBookingStatus != "" {
 		cmd += cmdContinuation + fmt.Sprintf("--expectBookingStatus=%s", flags.ExpectedBookingStatus)
 	}

--- a/cmd/service/db/data/testData.gen.json
+++ b/cmd/service/db/data/testData.gen.json
@@ -12,7 +12,7 @@
         "id": "",
         "operator": ""
       },
-      "passengerPickupDate": 1209600,
+      "passengerPickupDate": 0,
       "type": "DYNAMIC"
     },
     {
@@ -27,7 +27,7 @@
         "id": "",
         "operator": ""
       },
-      "passengerPickupDate": 1209600,
+      "passengerPickupDate": 0,
       "type": "DYNAMIC"
     },
     {
@@ -42,7 +42,7 @@
         "id": "",
         "operator": ""
       },
-      "passengerPickupDate": 1814400,
+      "passengerPickupDate": 0,
       "type": "DYNAMIC"
     },
     {
@@ -57,7 +57,7 @@
         "id": "",
         "operator": ""
       },
-      "passengerPickupDate": 1814400,
+      "passengerPickupDate": 0,
       "type": "DYNAMIC"
     },
     {
@@ -72,7 +72,7 @@
         "id": "",
         "operator": ""
       },
-      "passengerPickupDate": 2419200,
+      "passengerPickupDate": 0,
       "type": "DYNAMIC"
     },
     {
@@ -87,7 +87,7 @@
         "id": "",
         "operator": ""
       },
-      "passengerPickupDate": 3024000,
+      "passengerPickupDate": 0,
       "type": "DYNAMIC"
     },
     {
@@ -102,7 +102,7 @@
         "id": "",
         "operator": ""
       },
-      "passengerPickupDate": 3628800,
+      "passengerPickupDate": 0,
       "type": "DYNAMIC"
     },
     {
@@ -408,8 +408,8 @@
         "id": "",
         "operator": ""
       },
-      "driverDepartureDate": 0,
-      "passengerPickupDate": 0,
+      "driverDepartureDate": 10886400,
+      "passengerPickupDate": 10886400,
       "type": "DYNAMIC"
     },
     {
@@ -424,8 +424,8 @@
         "id": "",
         "operator": ""
       },
-      "driverDepartureDate": 0,
-      "passengerPickupDate": 0,
+      "driverDepartureDate": 11491200,
+      "passengerPickupDate": 11491200,
       "type": "DYNAMIC"
     },
     {
@@ -440,8 +440,8 @@
         "id": "",
         "operator": ""
       },
-      "driverDepartureDate": 0,
-      "passengerPickupDate": 0,
+      "driverDepartureDate": 11491200,
+      "passengerPickupDate": 11491200,
       "type": "DYNAMIC"
     },
     {
@@ -456,8 +456,8 @@
         "id": "",
         "operator": ""
       },
-      "driverDepartureDate": 0,
-      "passengerPickupDate": 0,
+      "driverDepartureDate": 12096000,
+      "passengerPickupDate": 12096000,
       "type": "DYNAMIC"
     },
     {
@@ -472,8 +472,8 @@
         "id": "",
         "operator": ""
       },
-      "driverDepartureDate": 0,
-      "passengerPickupDate": 0,
+      "driverDepartureDate": 12096000,
+      "passengerPickupDate": 12096000,
       "type": "DYNAMIC"
     },
     {
@@ -488,8 +488,8 @@
         "id": "",
         "operator": ""
       },
-      "driverDepartureDate": 0,
-      "passengerPickupDate": 0,
+      "driverDepartureDate": 12700800,
+      "passengerPickupDate": 12700800,
       "type": "DYNAMIC"
     },
     {
@@ -504,8 +504,8 @@
         "id": "",
         "operator": ""
       },
-      "driverDepartureDate": 0,
-      "passengerPickupDate": 0,
+      "driverDepartureDate": 13305600,
+      "passengerPickupDate": 13305600,
       "type": "DYNAMIC"
     },
     {
@@ -520,8 +520,8 @@
         "id": "",
         "operator": ""
       },
-      "driverDepartureDate": 0,
-      "passengerPickupDate": 0,
+      "driverDepartureDate": 13305600,
+      "passengerPickupDate": 13305600,
       "type": "DYNAMIC"
     },
     {
@@ -536,8 +536,8 @@
         "id": "",
         "operator": ""
       },
-      "driverDepartureDate": 0,
-      "passengerPickupDate": 0,
+      "driverDepartureDate": 13910400,
+      "passengerPickupDate": 13910400,
       "type": "DYNAMIC"
     },
     {
@@ -552,8 +552,8 @@
         "id": "",
         "operator": ""
       },
-      "driverDepartureDate": 0,
-      "passengerPickupDate": 0,
+      "driverDepartureDate": 13910400,
+      "passengerPickupDate": 13910400,
       "type": "DYNAMIC"
     },
     {
@@ -568,8 +568,8 @@
         "id": "",
         "operator": ""
       },
-      "driverDepartureDate": 0,
-      "passengerPickupDate": 0,
+      "driverDepartureDate": 14515200,
+      "passengerPickupDate": 14515200,
       "type": "DYNAMIC"
     },
     {
@@ -584,8 +584,8 @@
         "id": "",
         "operator": ""
       },
-      "driverDepartureDate": 0,
-      "passengerPickupDate": 0,
+      "driverDepartureDate": 15120000,
+      "passengerPickupDate": 15120000,
       "type": "DYNAMIC"
     },
     {
@@ -600,8 +600,8 @@
         "id": "",
         "operator": ""
       },
-      "driverDepartureDate": 0,
-      "passengerPickupDate": 5,
+      "driverDepartureDate": 15724800,
+      "passengerPickupDate": 15724805,
       "type": "DYNAMIC"
     },
     {
@@ -616,8 +616,8 @@
         "id": "",
         "operator": ""
       },
-      "driverDepartureDate": 0,
-      "passengerPickupDate": 15,
+      "driverDepartureDate": 16329600,
+      "passengerPickupDate": 16329615,
       "type": "DYNAMIC"
     },
     {
@@ -632,8 +632,8 @@
         "id": "",
         "operator": ""
       },
-      "driverDepartureDate": 0,
-      "passengerPickupDate": 25,
+      "driverDepartureDate": 16934400,
+      "passengerPickupDate": 16934425,
       "type": "DYNAMIC"
     },
     {
@@ -648,8 +648,8 @@
         "id": "",
         "operator": ""
       },
-      "driverDepartureDate": 0,
-      "passengerPickupDate": 15,
+      "driverDepartureDate": 16934400,
+      "passengerPickupDate": 16934415,
       "type": "DYNAMIC"
     },
     {
@@ -664,8 +664,8 @@
         "id": "",
         "operator": ""
       },
-      "driverDepartureDate": 0,
-      "passengerPickupDate": 0,
+      "driverDepartureDate": 17539200,
+      "passengerPickupDate": 17539200,
       "type": "DYNAMIC"
     },
     {
@@ -680,8 +680,8 @@
         "id": "",
         "operator": ""
       },
-      "driverDepartureDate": 0,
-      "passengerPickupDate": 0,
+      "driverDepartureDate": 18144000,
+      "passengerPickupDate": 18144000,
       "type": "DYNAMIC"
     },
     {
@@ -696,8 +696,8 @@
         "id": "",
         "operator": ""
       },
-      "driverDepartureDate": 0,
-      "passengerPickupDate": 0,
+      "driverDepartureDate": 18748800,
+      "passengerPickupDate": 18748800,
       "type": "DYNAMIC"
     },
     {
@@ -712,8 +712,8 @@
         "id": "",
         "operator": ""
       },
-      "driverDepartureDate": 0,
-      "passengerPickupDate": 0,
+      "driverDepartureDate": 18748800,
+      "passengerPickupDate": 18748800,
       "type": "DYNAMIC"
     },
     {
@@ -728,8 +728,8 @@
         "id": "",
         "operator": ""
       },
-      "driverDepartureDate": 0,
-      "passengerPickupDate": 0,
+      "driverDepartureDate": 18748800,
+      "passengerPickupDate": 18748800,
       "type": "DYNAMIC"
     },
     {
@@ -744,8 +744,8 @@
         "id": "",
         "operator": ""
       },
-      "driverDepartureDate": 0,
-      "passengerPickupDate": 0,
+      "driverDepartureDate": 18748800,
+      "passengerPickupDate": 18748800,
       "type": "DYNAMIC"
     },
     {
@@ -824,47 +824,7 @@
         "id": "",
         "operator": ""
       },
-      "id": "1b06f7b5-67c7-f231-9bf3-9f28aa391537",
-      "passenger": {
-        "alias": "",
-        "id": "",
-        "operator": ""
-      },
-      "passengerDropLat": 0,
-      "passengerDropLng": 0,
-      "passengerPickupDate": 0,
-      "passengerPickupLat": 0,
-      "passengerPickupLng": 0,
-      "price": {},
-      "status": "VALIDATED"
-    },
-    {
-      "driver": {
-        "alias": "",
-        "id": "",
-        "operator": ""
-      },
-      "id": "f84f0c93-2990-ae59-ee94-8e4413ce4e81",
-      "passenger": {
-        "alias": "",
-        "id": "",
-        "operator": ""
-      },
-      "passengerDropLat": 0,
-      "passengerDropLng": 0,
-      "passengerPickupDate": 0,
-      "passengerPickupLat": 0,
-      "passengerPickupLng": 0,
-      "price": {},
-      "status": "CANCELLED"
-    },
-    {
-      "driver": {
-        "alias": "",
-        "id": "",
-        "operator": ""
-      },
-      "id": "cc8c67ad-62d4-b3b1-ee30-02a37a51035f",
+      "id": "2f8282cb-e2f9-696f-3144-c0aa4ced56db",
       "passenger": {
         "alias": "",
         "id": "",
@@ -884,7 +844,7 @@
         "id": "",
         "operator": ""
       },
-      "id": "b2892d57-f402-cd4a-2c11-08cc823ae0c5",
+      "id": "85fbe72b-6064-2890-04a5-31f967898df5",
       "passenger": {
         "alias": "",
         "id": "",
@@ -896,7 +856,7 @@
       "passengerPickupLat": 0,
       "passengerPickupLng": 0,
       "price": {},
-      "status": "CANCELLED"
+      "status": "WAITING_CONFIRMATION"
     },
     {
       "driver": {
@@ -924,7 +884,7 @@
         "id": "",
         "operator": ""
       },
-      "id": "68087cc0-282c-35d9-ad8b-51bf6a35a933",
+      "id": "ffda9299-b1d9-fafa-3d47-844c536f73c2",
       "passenger": {
         "alias": "",
         "id": "",
@@ -936,7 +896,27 @@
       "passengerPickupLat": 0,
       "passengerPickupLng": 0,
       "price": {},
-      "status": "WAITING_CONFIRMATION"
+      "status": "CONFIRMED"
+    },
+    {
+      "driver": {
+        "alias": "",
+        "id": "",
+        "operator": ""
+      },
+      "id": "b2892d57-f402-cd4a-2c11-08cc823ae0c5",
+      "passenger": {
+        "alias": "",
+        "id": "",
+        "operator": ""
+      },
+      "passengerDropLat": 0,
+      "passengerDropLng": 0,
+      "passengerPickupDate": 0,
+      "passengerPickupLat": 0,
+      "passengerPickupLng": 0,
+      "price": {},
+      "status": "CANCELLED"
     },
     {
       "driver": {
@@ -984,6 +964,66 @@
         "id": "",
         "operator": ""
       },
+      "id": "68087cc0-282c-35d9-ad8b-51bf6a35a933",
+      "passenger": {
+        "alias": "",
+        "id": "",
+        "operator": ""
+      },
+      "passengerDropLat": 0,
+      "passengerDropLng": 0,
+      "passengerPickupDate": 0,
+      "passengerPickupLat": 0,
+      "passengerPickupLng": 0,
+      "price": {},
+      "status": "WAITING_CONFIRMATION"
+    },
+    {
+      "driver": {
+        "alias": "",
+        "id": "",
+        "operator": ""
+      },
+      "id": "1b06f7b5-67c7-f231-9bf3-9f28aa391537",
+      "passenger": {
+        "alias": "",
+        "id": "",
+        "operator": ""
+      },
+      "passengerDropLat": 0,
+      "passengerDropLng": 0,
+      "passengerPickupDate": 0,
+      "passengerPickupLat": 0,
+      "passengerPickupLng": 0,
+      "price": {},
+      "status": "VALIDATED"
+    },
+    {
+      "driver": {
+        "alias": "",
+        "id": "",
+        "operator": ""
+      },
+      "id": "f84f0c93-2990-ae59-ee94-8e4413ce4e81",
+      "passenger": {
+        "alias": "",
+        "id": "",
+        "operator": ""
+      },
+      "passengerDropLat": 0,
+      "passengerDropLng": 0,
+      "passengerPickupDate": 0,
+      "passengerPickupLat": 0,
+      "passengerPickupLng": 0,
+      "price": {},
+      "status": "CANCELLED"
+    },
+    {
+      "driver": {
+        "alias": "",
+        "id": "",
+        "operator": ""
+      },
       "id": "ce140275-2398-b471-e9a9-4ddcec56059b",
       "passenger": {
         "alias": "",
@@ -1004,47 +1044,7 @@
         "id": "",
         "operator": ""
       },
-      "id": "ffda9299-b1d9-fafa-3d47-844c536f73c2",
-      "passenger": {
-        "alias": "",
-        "id": "",
-        "operator": ""
-      },
-      "passengerDropLat": 0,
-      "passengerDropLng": 0,
-      "passengerPickupDate": 0,
-      "passengerPickupLat": 0,
-      "passengerPickupLng": 0,
-      "price": {},
-      "status": "CONFIRMED"
-    },
-    {
-      "driver": {
-        "alias": "",
-        "id": "",
-        "operator": ""
-      },
-      "id": "2f8282cb-e2f9-696f-3144-c0aa4ced56db",
-      "passenger": {
-        "alias": "",
-        "id": "",
-        "operator": ""
-      },
-      "passengerDropLat": 0,
-      "passengerDropLng": 0,
-      "passengerPickupDate": 0,
-      "passengerPickupLat": 0,
-      "passengerPickupLng": 0,
-      "price": {},
-      "status": "WAITING_CONFIRMATION"
-    },
-    {
-      "driver": {
-        "alias": "",
-        "id": "",
-        "operator": ""
-      },
-      "id": "85fbe72b-6064-2890-04a5-31f967898df5",
+      "id": "cc8c67ad-62d4-b3b1-ee30-02a37a51035f",
       "passenger": {
         "alias": "",
         "id": "",

--- a/cmd/service/db/data/testData.gen.json
+++ b/cmd/service/db/data/testData.gen.json
@@ -329,70 +329,6 @@
       },
       "passengerPickupDate": 9072000,
       "type": "DYNAMIC"
-    },
-    {
-      "duration": 3600,
-      "operator": "operator.example.org",
-      "passengerDropLat": 48.8450234,
-      "passengerDropLng": 2.3997529,
-      "passengerPickupLat": 47.461737,
-      "passengerPickupLng": 1.061393,
-      "driver": {
-        "alias": "bob",
-        "id": "1",
-        "operator": ""
-      },
-      "id": "aui",
-      "passengerPickupDate": 1665579951,
-      "type": "DYNAMIC"
-    },
-    {
-      "duration": 3600,
-      "operator": "operator.example.org",
-      "passengerDropLat": 48.8450234,
-      "passengerDropLng": 2.3997529,
-      "passengerPickupLat": 47.461737,
-      "passengerPickupLng": 1.061393,
-      "driver": {
-        "alias": "bob",
-        "id": "1",
-        "operator": ""
-      },
-      "id": "pio",
-      "passengerPickupDate": 1665579951,
-      "type": "DYNAMIC"
-    },
-    {
-      "duration": 3600,
-      "operator": "operator.example.org",
-      "passengerDropLat": 48.8450234,
-      "passengerDropLng": 2.3997529,
-      "passengerPickupLat": 47.461737,
-      "passengerPickupLng": 1.061393,
-      "driver": {
-        "alias": "bob",
-        "id": "1",
-        "operator": ""
-      },
-      "id": "aui",
-      "passengerPickupDate": 1665579951,
-      "type": "DYNAMIC"
-    },
-    {
-      "duration": 3600,
-      "operator": "operator.example.org",
-      "passengerDropLat": 48.8450234,
-      "passengerDropLng": 2.3997529,
-      "passengerPickupLat": 47.461737,
-      "passengerPickupLng": 1.061393,
-      "driver": {
-        "alias": "bob",
-        "id": "1",
-        "operator": ""
-      },
-      "id": "pio",
-      "passengerPickupDate": 1665579951,
-      "type": "DYNAMIC"
     }
   ],
   "passengerJourneys": [
@@ -747,77 +683,29 @@
       "driverDepartureDate": 18748800,
       "passengerPickupDate": 18748800,
       "type": "DYNAMIC"
-    },
-    {
-      "duration": 3600,
-      "operator": "operator.example.org",
-      "passengerDropLat": 48.8450234,
-      "passengerDropLng": 2.3997529,
-      "passengerPickupLat": 47.461737,
-      "passengerPickupLng": 1.061393,
-      "passenger": {
-        "alias": "",
-        "id": "",
-        "operator": ""
-      },
-      "driverDepartureDate": 1665576650,
-      "id": "aui",
-      "passengerPickupDate": 1665579951,
-      "type": "DYNAMIC"
-    },
-    {
-      "duration": 3600,
-      "operator": "operator.example.org",
-      "passengerDropLat": 48.8450234,
-      "passengerDropLng": 2.3997529,
-      "passengerPickupLat": 47.461737,
-      "passengerPickupLng": 1.061393,
-      "passenger": {
-        "alias": "",
-        "id": "",
-        "operator": ""
-      },
-      "driverDepartureDate": 1665576650,
-      "id": "pio",
-      "passengerPickupDate": 1665579951,
-      "type": "DYNAMIC"
-    },
-    {
-      "duration": 3600,
-      "operator": "operator.example.org",
-      "passengerDropLat": 48.8450234,
-      "passengerDropLng": 2.3997529,
-      "passengerPickupLat": 47.461737,
-      "passengerPickupLng": 1.061393,
-      "passenger": {
-        "alias": "",
-        "id": "",
-        "operator": ""
-      },
-      "driverDepartureDate": 1665576650,
-      "id": "aui",
-      "passengerPickupDate": 1665579951,
-      "type": "DYNAMIC"
-    },
-    {
-      "duration": 3600,
-      "operator": "operator.example.org",
-      "passengerDropLat": 48.8450234,
-      "passengerDropLng": 2.3997529,
-      "passengerPickupLat": 47.461737,
-      "passengerPickupLng": 1.061393,
-      "passenger": {
-        "alias": "",
-        "id": "",
-        "operator": ""
-      },
-      "driverDepartureDate": 1665576650,
-      "id": "pio",
-      "passengerPickupDate": 1665579951,
-      "type": "DYNAMIC"
     }
   ],
   "bookings": [
+    {
+      "driver": {
+        "alias": "",
+        "id": "",
+        "operator": ""
+      },
+      "id": "0ad346f9-e692-3ab1-d2f0-91785e9ca0ea",
+      "passenger": {
+        "alias": "",
+        "id": "",
+        "operator": ""
+      },
+      "passengerDropLat": 0,
+      "passengerDropLng": 0,
+      "passengerPickupDate": 0,
+      "passengerPickupLat": 0,
+      "passengerPickupLng": 0,
+      "price": {},
+      "status": "WAITING_CONFIRMATION"
+    },
     {
       "driver": {
         "alias": "",
@@ -837,6 +725,26 @@
       "passengerPickupLng": 0,
       "price": {},
       "status": "WAITING_CONFIRMATION"
+    },
+    {
+      "driver": {
+        "alias": "",
+        "id": "",
+        "operator": ""
+      },
+      "id": "1b06f7b5-67c7-f231-9bf3-9f28aa391537",
+      "passenger": {
+        "alias": "",
+        "id": "",
+        "operator": ""
+      },
+      "passengerDropLat": 0,
+      "passengerDropLng": 0,
+      "passengerPickupDate": 0,
+      "passengerPickupLat": 0,
+      "passengerPickupLng": 0,
+      "price": {},
+      "status": "VALIDATED"
     },
     {
       "driver": {
@@ -884,126 +792,6 @@
         "id": "",
         "operator": ""
       },
-      "id": "ffda9299-b1d9-fafa-3d47-844c536f73c2",
-      "passenger": {
-        "alias": "",
-        "id": "",
-        "operator": ""
-      },
-      "passengerDropLat": 0,
-      "passengerDropLng": 0,
-      "passengerPickupDate": 0,
-      "passengerPickupLat": 0,
-      "passengerPickupLng": 0,
-      "price": {},
-      "status": "CONFIRMED"
-    },
-    {
-      "driver": {
-        "alias": "",
-        "id": "",
-        "operator": ""
-      },
-      "id": "85fbe72b-6064-2890-04a5-31f967898df5",
-      "passenger": {
-        "alias": "",
-        "id": "",
-        "operator": ""
-      },
-      "passengerDropLat": 0,
-      "passengerDropLng": 0,
-      "passengerPickupDate": 0,
-      "passengerPickupLat": 0,
-      "passengerPickupLng": 0,
-      "price": {},
-      "status": "WAITING_CONFIRMATION"
-    },
-    {
-      "driver": {
-        "alias": "",
-        "id": "",
-        "operator": ""
-      },
-      "id": "590c1440-9888-b5b0-7d51-a817ee07c3f2",
-      "passenger": {
-        "alias": "",
-        "id": "",
-        "operator": ""
-      },
-      "passengerDropLat": 0,
-      "passengerDropLng": 0,
-      "passengerPickupDate": 0,
-      "passengerPickupLat": 0,
-      "passengerPickupLng": 0,
-      "price": {},
-      "status": "WAITING_CONFIRMATION"
-    },
-    {
-      "driver": {
-        "alias": "",
-        "id": "",
-        "operator": ""
-      },
-      "id": "0ad346f9-e692-3ab1-d2f0-91785e9ca0ea",
-      "passenger": {
-        "alias": "",
-        "id": "",
-        "operator": ""
-      },
-      "passengerDropLat": 0,
-      "passengerDropLng": 0,
-      "passengerPickupDate": 0,
-      "passengerPickupLat": 0,
-      "passengerPickupLng": 0,
-      "price": {},
-      "status": "WAITING_CONFIRMATION"
-    },
-    {
-      "driver": {
-        "alias": "",
-        "id": "",
-        "operator": ""
-      },
-      "id": "f84f0c93-2990-ae59-ee94-8e4413ce4e81",
-      "passenger": {
-        "alias": "",
-        "id": "",
-        "operator": ""
-      },
-      "passengerDropLat": 0,
-      "passengerDropLng": 0,
-      "passengerPickupDate": 0,
-      "passengerPickupLat": 0,
-      "passengerPickupLng": 0,
-      "price": {},
-      "status": "CANCELLED"
-    },
-    {
-      "driver": {
-        "alias": "",
-        "id": "",
-        "operator": ""
-      },
-      "id": "b2892d57-f402-cd4a-2c11-08cc823ae0c5",
-      "passenger": {
-        "alias": "",
-        "id": "",
-        "operator": ""
-      },
-      "passengerDropLat": 0,
-      "passengerDropLng": 0,
-      "passengerPickupDate": 0,
-      "passengerPickupLat": 0,
-      "passengerPickupLng": 0,
-      "price": {},
-      "status": "CANCELLED"
-    },
-    {
-      "driver": {
-        "alias": "",
-        "id": "",
-        "operator": ""
-      },
       "id": "2f8282cb-e2f9-696f-3144-c0aa4ced56db",
       "passenger": {
         "alias": "",
@@ -1044,7 +832,7 @@
         "id": "",
         "operator": ""
       },
-      "id": "1b06f7b5-67c7-f231-9bf3-9f28aa391537",
+      "id": "590c1440-9888-b5b0-7d51-a817ee07c3f2",
       "passenger": {
         "alias": "",
         "id": "",
@@ -1056,7 +844,87 @@
       "passengerPickupLat": 0,
       "passengerPickupLng": 0,
       "price": {},
-      "status": "VALIDATED"
+      "status": "WAITING_CONFIRMATION"
+    },
+    {
+      "driver": {
+        "alias": "",
+        "id": "",
+        "operator": ""
+      },
+      "id": "b2892d57-f402-cd4a-2c11-08cc823ae0c5",
+      "passenger": {
+        "alias": "",
+        "id": "",
+        "operator": ""
+      },
+      "passengerDropLat": 0,
+      "passengerDropLng": 0,
+      "passengerPickupDate": 0,
+      "passengerPickupLat": 0,
+      "passengerPickupLng": 0,
+      "price": {},
+      "status": "CANCELLED"
+    },
+    {
+      "driver": {
+        "alias": "",
+        "id": "",
+        "operator": ""
+      },
+      "id": "85fbe72b-6064-2890-04a5-31f967898df5",
+      "passenger": {
+        "alias": "",
+        "id": "",
+        "operator": ""
+      },
+      "passengerDropLat": 0,
+      "passengerDropLng": 0,
+      "passengerPickupDate": 0,
+      "passengerPickupLat": 0,
+      "passengerPickupLng": 0,
+      "price": {},
+      "status": "WAITING_CONFIRMATION"
+    },
+    {
+      "driver": {
+        "alias": "",
+        "id": "",
+        "operator": ""
+      },
+      "id": "f84f0c93-2990-ae59-ee94-8e4413ce4e81",
+      "passenger": {
+        "alias": "",
+        "id": "",
+        "operator": ""
+      },
+      "passengerDropLat": 0,
+      "passengerDropLng": 0,
+      "passengerPickupDate": 0,
+      "passengerPickupLat": 0,
+      "passengerPickupLng": 0,
+      "price": {},
+      "status": "CANCELLED"
+    },
+    {
+      "driver": {
+        "alias": "",
+        "id": "",
+        "operator": ""
+      },
+      "id": "ffda9299-b1d9-fafa-3d47-844c536f73c2",
+      "passenger": {
+        "alias": "",
+        "id": "",
+        "operator": ""
+      },
+      "passengerDropLat": 0,
+      "passengerDropLng": 0,
+      "passengerPickupDate": 0,
+      "passengerPickupLat": 0,
+      "passengerPickupLng": 0,
+      "price": {},
+      "status": "CONFIRMED"
     }
   ],
   "users": [

--- a/cmd/service/db/data/testData.gen.json
+++ b/cmd/service/db/data/testData.gen.json
@@ -12,7 +12,7 @@
         "id": "",
         "operator": ""
       },
-      "passengerPickupDate": 0,
+      "passengerPickupDate": 1209600,
       "type": "DYNAMIC"
     },
     {
@@ -27,7 +27,7 @@
         "id": "",
         "operator": ""
       },
-      "passengerPickupDate": 0,
+      "passengerPickupDate": 1209600,
       "type": "DYNAMIC"
     },
     {
@@ -42,7 +42,7 @@
         "id": "",
         "operator": ""
       },
-      "passengerPickupDate": 0,
+      "passengerPickupDate": 1814400,
       "type": "DYNAMIC"
     },
     {
@@ -57,7 +57,7 @@
         "id": "",
         "operator": ""
       },
-      "passengerPickupDate": 0,
+      "passengerPickupDate": 1814400,
       "type": "DYNAMIC"
     },
     {
@@ -72,7 +72,7 @@
         "id": "",
         "operator": ""
       },
-      "passengerPickupDate": 0,
+      "passengerPickupDate": 2419200,
       "type": "DYNAMIC"
     },
     {
@@ -87,7 +87,7 @@
         "id": "",
         "operator": ""
       },
-      "passengerPickupDate": 0,
+      "passengerPickupDate": 3024000,
       "type": "DYNAMIC"
     },
     {
@@ -102,7 +102,7 @@
         "id": "",
         "operator": ""
       },
-      "passengerPickupDate": 0,
+      "passengerPickupDate": 3628800,
       "type": "DYNAMIC"
     },
     {
@@ -117,7 +117,7 @@
         "id": "",
         "operator": ""
       },
-      "passengerPickupDate": 0,
+      "passengerPickupDate": 3628800,
       "type": "DYNAMIC"
     },
     {
@@ -132,7 +132,7 @@
         "id": "",
         "operator": ""
       },
-      "passengerPickupDate": 0,
+      "passengerPickupDate": 4233600,
       "type": "DYNAMIC"
     },
     {
@@ -147,7 +147,7 @@
         "id": "",
         "operator": ""
       },
-      "passengerPickupDate": 0,
+      "passengerPickupDate": 4233600,
       "type": "DYNAMIC"
     },
     {
@@ -162,7 +162,7 @@
         "id": "",
         "operator": ""
       },
-      "passengerPickupDate": 0,
+      "passengerPickupDate": 4838400,
       "type": "DYNAMIC"
     },
     {
@@ -177,7 +177,7 @@
         "id": "",
         "operator": ""
       },
-      "passengerPickupDate": 0,
+      "passengerPickupDate": 5443200,
       "type": "DYNAMIC"
     },
     {
@@ -192,7 +192,7 @@
         "id": "",
         "operator": ""
       },
-      "passengerPickupDate": 5,
+      "passengerPickupDate": 6048005,
       "type": "DYNAMIC"
     },
     {
@@ -207,7 +207,7 @@
         "id": "",
         "operator": ""
       },
-      "passengerPickupDate": 15,
+      "passengerPickupDate": 6652815,
       "type": "DYNAMIC"
     },
     {
@@ -222,7 +222,7 @@
         "id": "",
         "operator": ""
       },
-      "passengerPickupDate": 25,
+      "passengerPickupDate": 7257625,
       "type": "DYNAMIC"
     },
     {
@@ -237,7 +237,7 @@
         "id": "",
         "operator": ""
       },
-      "passengerPickupDate": 15,
+      "passengerPickupDate": 7257615,
       "type": "DYNAMIC"
     },
     {
@@ -252,7 +252,7 @@
         "id": "",
         "operator": ""
       },
-      "passengerPickupDate": 0,
+      "passengerPickupDate": 7862400,
       "type": "DYNAMIC"
     },
     {
@@ -267,7 +267,7 @@
         "id": "",
         "operator": ""
       },
-      "passengerPickupDate": 0,
+      "passengerPickupDate": 8467200,
       "type": "DYNAMIC"
     },
     {
@@ -282,7 +282,7 @@
         "id": "",
         "operator": ""
       },
-      "passengerPickupDate": 0,
+      "passengerPickupDate": 9072000,
       "type": "DYNAMIC"
     },
     {
@@ -297,7 +297,7 @@
         "id": "",
         "operator": ""
       },
-      "passengerPickupDate": 0,
+      "passengerPickupDate": 9072000,
       "type": "DYNAMIC"
     },
     {
@@ -312,7 +312,7 @@
         "id": "",
         "operator": ""
       },
-      "passengerPickupDate": 0,
+      "passengerPickupDate": 9072000,
       "type": "DYNAMIC"
     },
     {
@@ -327,7 +327,7 @@
         "id": "",
         "operator": ""
       },
-      "passengerPickupDate": 0,
+      "passengerPickupDate": 9072000,
       "type": "DYNAMIC"
     },
     {
@@ -824,66 +824,6 @@
         "id": "",
         "operator": ""
       },
-      "id": "e2807d9c-1dce-26af-00ca-81d4fe11c23e",
-      "passenger": {
-        "alias": "",
-        "id": "",
-        "operator": ""
-      },
-      "passengerDropLat": 0,
-      "passengerDropLng": 0,
-      "passengerPickupDate": 0,
-      "passengerPickupLat": 0,
-      "passengerPickupLng": 0,
-      "price": {},
-      "status": "WAITING_CONFIRMATION"
-    },
-    {
-      "driver": {
-        "alias": "",
-        "id": "",
-        "operator": ""
-      },
-      "id": "68087cc0-282c-35d9-ad8b-51bf6a35a933",
-      "passenger": {
-        "alias": "",
-        "id": "",
-        "operator": ""
-      },
-      "passengerDropLat": 0,
-      "passengerDropLng": 0,
-      "passengerPickupDate": 0,
-      "passengerPickupLat": 0,
-      "passengerPickupLng": 0,
-      "price": {},
-      "status": "WAITING_CONFIRMATION"
-    },
-    {
-      "driver": {
-        "alias": "",
-        "id": "",
-        "operator": ""
-      },
-      "id": "b2892d57-f402-cd4a-2c11-08cc823ae0c5",
-      "passenger": {
-        "alias": "",
-        "id": "",
-        "operator": ""
-      },
-      "passengerDropLat": 0,
-      "passengerDropLng": 0,
-      "passengerPickupDate": 0,
-      "passengerPickupLat": 0,
-      "passengerPickupLng": 0,
-      "price": {},
-      "status": "CANCELLED"
-    },
-    {
-      "driver": {
-        "alias": "",
-        "id": "",
-        "operator": ""
-      },
       "id": "1b06f7b5-67c7-f231-9bf3-9f28aa391537",
       "passenger": {
         "alias": "",
@@ -924,6 +864,126 @@
         "id": "",
         "operator": ""
       },
+      "id": "cc8c67ad-62d4-b3b1-ee30-02a37a51035f",
+      "passenger": {
+        "alias": "",
+        "id": "",
+        "operator": ""
+      },
+      "passengerDropLat": 0,
+      "passengerDropLng": 0,
+      "passengerPickupDate": 0,
+      "passengerPickupLat": 0,
+      "passengerPickupLng": 0,
+      "price": {},
+      "status": "WAITING_CONFIRMATION"
+    },
+    {
+      "driver": {
+        "alias": "",
+        "id": "",
+        "operator": ""
+      },
+      "id": "b2892d57-f402-cd4a-2c11-08cc823ae0c5",
+      "passenger": {
+        "alias": "",
+        "id": "",
+        "operator": ""
+      },
+      "passengerDropLat": 0,
+      "passengerDropLng": 0,
+      "passengerPickupDate": 0,
+      "passengerPickupLat": 0,
+      "passengerPickupLng": 0,
+      "price": {},
+      "status": "CANCELLED"
+    },
+    {
+      "driver": {
+        "alias": "",
+        "id": "",
+        "operator": ""
+      },
+      "id": "590c1440-9888-b5b0-7d51-a817ee07c3f2",
+      "passenger": {
+        "alias": "",
+        "id": "",
+        "operator": ""
+      },
+      "passengerDropLat": 0,
+      "passengerDropLng": 0,
+      "passengerPickupDate": 0,
+      "passengerPickupLat": 0,
+      "passengerPickupLng": 0,
+      "price": {},
+      "status": "WAITING_CONFIRMATION"
+    },
+    {
+      "driver": {
+        "alias": "",
+        "id": "",
+        "operator": ""
+      },
+      "id": "68087cc0-282c-35d9-ad8b-51bf6a35a933",
+      "passenger": {
+        "alias": "",
+        "id": "",
+        "operator": ""
+      },
+      "passengerDropLat": 0,
+      "passengerDropLng": 0,
+      "passengerPickupDate": 0,
+      "passengerPickupLat": 0,
+      "passengerPickupLng": 0,
+      "price": {},
+      "status": "WAITING_CONFIRMATION"
+    },
+    {
+      "driver": {
+        "alias": "",
+        "id": "",
+        "operator": ""
+      },
+      "id": "e2807d9c-1dce-26af-00ca-81d4fe11c23e",
+      "passenger": {
+        "alias": "",
+        "id": "",
+        "operator": ""
+      },
+      "passengerDropLat": 0,
+      "passengerDropLng": 0,
+      "passengerPickupDate": 0,
+      "passengerPickupLat": 0,
+      "passengerPickupLng": 0,
+      "price": {},
+      "status": "WAITING_CONFIRMATION"
+    },
+    {
+      "driver": {
+        "alias": "",
+        "id": "",
+        "operator": ""
+      },
+      "id": "0ad346f9-e692-3ab1-d2f0-91785e9ca0ea",
+      "passenger": {
+        "alias": "",
+        "id": "",
+        "operator": ""
+      },
+      "passengerDropLat": 0,
+      "passengerDropLng": 0,
+      "passengerPickupDate": 0,
+      "passengerPickupLat": 0,
+      "passengerPickupLng": 0,
+      "price": {},
+      "status": "WAITING_CONFIRMATION"
+    },
+    {
+      "driver": {
+        "alias": "",
+        "id": "",
+        "operator": ""
+      },
       "id": "ce140275-2398-b471-e9a9-4ddcec56059b",
       "passenger": {
         "alias": "",
@@ -944,7 +1004,7 @@
         "id": "",
         "operator": ""
       },
-      "id": "cc8c67ad-62d4-b3b1-ee30-02a37a51035f",
+      "id": "ffda9299-b1d9-fafa-3d47-844c536f73c2",
       "passenger": {
         "alias": "",
         "id": "",
@@ -956,7 +1016,7 @@
       "passengerPickupLat": 0,
       "passengerPickupLng": 0,
       "price": {},
-      "status": "WAITING_CONFIRMATION"
+      "status": "CONFIRMED"
     },
     {
       "driver": {
@@ -997,66 +1057,6 @@
       "passengerPickupLng": 0,
       "price": {},
       "status": "WAITING_CONFIRMATION"
-    },
-    {
-      "driver": {
-        "alias": "",
-        "id": "",
-        "operator": ""
-      },
-      "id": "590c1440-9888-b5b0-7d51-a817ee07c3f2",
-      "passenger": {
-        "alias": "",
-        "id": "",
-        "operator": ""
-      },
-      "passengerDropLat": 0,
-      "passengerDropLng": 0,
-      "passengerPickupDate": 0,
-      "passengerPickupLat": 0,
-      "passengerPickupLng": 0,
-      "price": {},
-      "status": "WAITING_CONFIRMATION"
-    },
-    {
-      "driver": {
-        "alias": "",
-        "id": "",
-        "operator": ""
-      },
-      "id": "0ad346f9-e692-3ab1-d2f0-91785e9ca0ea",
-      "passenger": {
-        "alias": "",
-        "id": "",
-        "operator": ""
-      },
-      "passengerDropLat": 0,
-      "passengerDropLng": 0,
-      "passengerPickupDate": 0,
-      "passengerPickupLat": 0,
-      "passengerPickupLng": 0,
-      "price": {},
-      "status": "WAITING_CONFIRMATION"
-    },
-    {
-      "driver": {
-        "alias": "",
-        "id": "",
-        "operator": ""
-      },
-      "id": "ffda9299-b1d9-fafa-3d47-844c536f73c2",
-      "passenger": {
-        "alias": "",
-        "id": "",
-        "operator": ""
-      },
-      "passengerDropLat": 0,
-      "passengerDropLng": 0,
-      "passengerPickupDate": 0,
-      "passengerPickupLat": 0,
-      "passengerPickupLng": 0,
-      "price": {},
-      "status": "CONFIRMED"
     }
   ],
   "users": [

--- a/cmd/service/db/data/testData.gen.json
+++ b/cmd/service/db/data/testData.gen.json
@@ -12,7 +12,7 @@
         "id": "",
         "operator": ""
       },
-      "passengerPickupDate": 0,
+      "passengerPickupDate": 1209600,
       "type": "DYNAMIC"
     },
     {
@@ -27,7 +27,7 @@
         "id": "",
         "operator": ""
       },
-      "passengerPickupDate": 0,
+      "passengerPickupDate": 1209600,
       "type": "DYNAMIC"
     },
     {
@@ -42,7 +42,7 @@
         "id": "",
         "operator": ""
       },
-      "passengerPickupDate": 0,
+      "passengerPickupDate": 1814400,
       "type": "DYNAMIC"
     },
     {
@@ -57,7 +57,7 @@
         "id": "",
         "operator": ""
       },
-      "passengerPickupDate": 0,
+      "passengerPickupDate": 1814400,
       "type": "DYNAMIC"
     },
     {
@@ -72,7 +72,7 @@
         "id": "",
         "operator": ""
       },
-      "passengerPickupDate": 0,
+      "passengerPickupDate": 2419200,
       "type": "DYNAMIC"
     },
     {
@@ -87,7 +87,7 @@
         "id": "",
         "operator": ""
       },
-      "passengerPickupDate": 0,
+      "passengerPickupDate": 3024000,
       "type": "DYNAMIC"
     },
     {
@@ -102,7 +102,7 @@
         "id": "",
         "operator": ""
       },
-      "passengerPickupDate": 0,
+      "passengerPickupDate": 3628800,
       "type": "DYNAMIC"
     },
     {
@@ -824,7 +824,7 @@
         "id": "",
         "operator": ""
       },
-      "id": "2f8282cb-e2f9-696f-3144-c0aa4ced56db",
+      "id": "68087cc0-282c-35d9-ad8b-51bf6a35a933",
       "passenger": {
         "alias": "",
         "id": "",
@@ -837,6 +837,66 @@
       "passengerPickupLng": 0,
       "price": {},
       "status": "WAITING_CONFIRMATION"
+    },
+    {
+      "driver": {
+        "alias": "",
+        "id": "",
+        "operator": ""
+      },
+      "id": "ce140275-2398-b471-e9a9-4ddcec56059b",
+      "passenger": {
+        "alias": "",
+        "id": "",
+        "operator": ""
+      },
+      "passengerDropLat": 0,
+      "passengerDropLng": 0,
+      "passengerPickupDate": 0,
+      "passengerPickupLat": 0,
+      "passengerPickupLng": 0,
+      "price": {},
+      "status": "WAITING_CONFIRMATION"
+    },
+    {
+      "driver": {
+        "alias": "",
+        "id": "",
+        "operator": ""
+      },
+      "id": "cc8c67ad-62d4-b3b1-ee30-02a37a51035f",
+      "passenger": {
+        "alias": "",
+        "id": "",
+        "operator": ""
+      },
+      "passengerDropLat": 0,
+      "passengerDropLng": 0,
+      "passengerPickupDate": 0,
+      "passengerPickupLat": 0,
+      "passengerPickupLng": 0,
+      "price": {},
+      "status": "WAITING_CONFIRMATION"
+    },
+    {
+      "driver": {
+        "alias": "",
+        "id": "",
+        "operator": ""
+      },
+      "id": "ffda9299-b1d9-fafa-3d47-844c536f73c2",
+      "passenger": {
+        "alias": "",
+        "id": "",
+        "operator": ""
+      },
+      "passengerDropLat": 0,
+      "passengerDropLng": 0,
+      "passengerPickupDate": 0,
+      "passengerPickupLat": 0,
+      "passengerPickupLng": 0,
+      "price": {},
+      "status": "CONFIRMED"
     },
     {
       "driver": {
@@ -884,7 +944,7 @@
         "id": "",
         "operator": ""
       },
-      "id": "ffda9299-b1d9-fafa-3d47-844c536f73c2",
+      "id": "0ad346f9-e692-3ab1-d2f0-91785e9ca0ea",
       "passenger": {
         "alias": "",
         "id": "",
@@ -896,7 +956,27 @@
       "passengerPickupLat": 0,
       "passengerPickupLng": 0,
       "price": {},
-      "status": "CONFIRMED"
+      "status": "WAITING_CONFIRMATION"
+    },
+    {
+      "driver": {
+        "alias": "",
+        "id": "",
+        "operator": ""
+      },
+      "id": "f84f0c93-2990-ae59-ee94-8e4413ce4e81",
+      "passenger": {
+        "alias": "",
+        "id": "",
+        "operator": ""
+      },
+      "passengerDropLat": 0,
+      "passengerDropLng": 0,
+      "passengerPickupDate": 0,
+      "passengerPickupLat": 0,
+      "passengerPickupLng": 0,
+      "price": {},
+      "status": "CANCELLED"
     },
     {
       "driver": {
@@ -924,47 +1004,27 @@
         "id": "",
         "operator": ""
       },
+      "id": "2f8282cb-e2f9-696f-3144-c0aa4ced56db",
+      "passenger": {
+        "alias": "",
+        "id": "",
+        "operator": ""
+      },
+      "passengerDropLat": 0,
+      "passengerDropLng": 0,
+      "passengerPickupDate": 0,
+      "passengerPickupLat": 0,
+      "passengerPickupLng": 0,
+      "price": {},
+      "status": "WAITING_CONFIRMATION"
+    },
+    {
+      "driver": {
+        "alias": "",
+        "id": "",
+        "operator": ""
+      },
       "id": "e2807d9c-1dce-26af-00ca-81d4fe11c23e",
-      "passenger": {
-        "alias": "",
-        "id": "",
-        "operator": ""
-      },
-      "passengerDropLat": 0,
-      "passengerDropLng": 0,
-      "passengerPickupDate": 0,
-      "passengerPickupLat": 0,
-      "passengerPickupLng": 0,
-      "price": {},
-      "status": "WAITING_CONFIRMATION"
-    },
-    {
-      "driver": {
-        "alias": "",
-        "id": "",
-        "operator": ""
-      },
-      "id": "0ad346f9-e692-3ab1-d2f0-91785e9ca0ea",
-      "passenger": {
-        "alias": "",
-        "id": "",
-        "operator": ""
-      },
-      "passengerDropLat": 0,
-      "passengerDropLng": 0,
-      "passengerPickupDate": 0,
-      "passengerPickupLat": 0,
-      "passengerPickupLng": 0,
-      "price": {},
-      "status": "WAITING_CONFIRMATION"
-    },
-    {
-      "driver": {
-        "alias": "",
-        "id": "",
-        "operator": ""
-      },
-      "id": "68087cc0-282c-35d9-ad8b-51bf6a35a933",
       "passenger": {
         "alias": "",
         "id": "",
@@ -997,66 +1057,6 @@
       "passengerPickupLng": 0,
       "price": {},
       "status": "VALIDATED"
-    },
-    {
-      "driver": {
-        "alias": "",
-        "id": "",
-        "operator": ""
-      },
-      "id": "f84f0c93-2990-ae59-ee94-8e4413ce4e81",
-      "passenger": {
-        "alias": "",
-        "id": "",
-        "operator": ""
-      },
-      "passengerDropLat": 0,
-      "passengerDropLng": 0,
-      "passengerPickupDate": 0,
-      "passengerPickupLat": 0,
-      "passengerPickupLng": 0,
-      "price": {},
-      "status": "CANCELLED"
-    },
-    {
-      "driver": {
-        "alias": "",
-        "id": "",
-        "operator": ""
-      },
-      "id": "ce140275-2398-b471-e9a9-4ddcec56059b",
-      "passenger": {
-        "alias": "",
-        "id": "",
-        "operator": ""
-      },
-      "passengerDropLat": 0,
-      "passengerDropLng": 0,
-      "passengerPickupDate": 0,
-      "passengerPickupLat": 0,
-      "passengerPickupLng": 0,
-      "price": {},
-      "status": "WAITING_CONFIRMATION"
-    },
-    {
-      "driver": {
-        "alias": "",
-        "id": "",
-        "operator": ""
-      },
-      "id": "cc8c67ad-62d4-b3b1-ee30-02a37a51035f",
-      "passenger": {
-        "alias": "",
-        "id": "",
-        "operator": ""
-      },
-      "passengerDropLat": 0,
-      "passengerDropLng": 0,
-      "passengerPickupDate": 0,
-      "passengerPickupLat": 0,
-      "passengerPickupLng": 0,
-      "price": {},
-      "status": "WAITING_CONFIRMATION"
     }
   ],
   "users": [

--- a/cmd/service/db/db.go
+++ b/cmd/service/db/db.go
@@ -155,8 +155,6 @@ func WriteData(m *Mock, w io.Writer) error {
 		return err
 	}
 
-	fmt.Println(string(jsonData))
-
 	_, err = w.Write(jsonData)
 	if err != nil {
 		return err

--- a/cmd/service/testing.go
+++ b/cmd/service/testing.go
@@ -453,6 +453,33 @@ func TestGetDriverJourneysHelper(
 
 //////////////////////////////////////////////////////////
 
+type getPassengerJourneysTestHelper struct {
+	params *api.GetPassengerJourneysParams
+}
+
+func (h getPassengerJourneysTestHelper) makeRequest() (*http.Request, error) {
+	return api.NewGetPassengerJourneysRequest(localServer, h.params)
+}
+
+func (h getPassengerJourneysTestHelper) callAPI(handler *StdCovServerImpl, ctx echo.Context) error {
+	return handler.GetPassengerJourneys(ctx, *h.params)
+}
+
+func (h getPassengerJourneysTestHelper) testResponse(request *http.Request, response *http.Response, flags test.Flags) []testassert.Result {
+	return test.TestGetPassengerJourneysResponse(request, response, flags)
+}
+
+func TestGetPassengerJourneysHelper(
+	t *testing.T,
+	mockDB *db.Mock,
+	params *api.GetPassengerJourneysParams,
+	flags test.Flags,
+) {
+	testAPI(t, getPassengerJourneysTestHelper{params}, mockDB, flags)
+}
+
+//////////////////////////////////////////////////////////
+
 func requestAll(t *testing.T, driverOrPassenger string) api.GetJourneysParams {
 	t.Helper()
 

--- a/cmd/service/testing.go
+++ b/cmd/service/testing.go
@@ -424,6 +424,35 @@ func TestPatchBookingsHelper(
 	testAPI(t, patchBookingsTestHelper{bookingID, status}, mockDB, flags)
 }
 
+//////////////////////////////////////////////////////////
+
+type getDriverJourneysTestHelper struct {
+	params *api.GetDriverJourneysParams
+}
+
+func (h getDriverJourneysTestHelper) makeRequest() (*http.Request, error) {
+	return api.NewGetDriverJourneysRequest(localServer, h.params)
+}
+
+func (h getDriverJourneysTestHelper) callAPI(handler *StdCovServerImpl, ctx echo.Context) error {
+	return handler.GetDriverJourneys(ctx, *h.params)
+}
+
+func (h getDriverJourneysTestHelper) testResponse(request *http.Request, response *http.Response, flags test.Flags) []testassert.Result {
+	return test.TestGetDriverJourneysResponse(request, response, flags)
+}
+
+func TestGetDriverJourneysHelper(
+	t *testing.T,
+	mockDB *db.Mock,
+	params *api.GetDriverJourneysParams,
+	flags test.Flags,
+) {
+	testAPI(t, getDriverJourneysTestHelper{params}, mockDB, flags)
+}
+
+//////////////////////////////////////////////////////////
+
 func requestAll(t *testing.T, driverOrPassenger string) api.GetJourneysParams {
 	t.Helper()
 

--- a/cmd/test/assert/assertion_implementation.go
+++ b/cmd/test/assert/assertion_implementation.go
@@ -267,7 +267,7 @@ func (a assertArrayNotEmpty) Execute() error {
 	}
 
 	if len(array) == 0 {
-		return errors.New("empty response not accepted with \"disallowEmpty\" option")
+		return errors.New("empty response not accepted with \"expectNonEmpty\" option")
 	}
 
 	return nil

--- a/cmd/test/commands/testCommands.gen.sh
+++ b/cmd/test/commands/testCommands.gen.sh
@@ -9,7 +9,9 @@ go run main.go test \
   --method=GET \
   --url="$SERVER/driver_journeys?arrivalLat=0&arrivalLng=0&departureDate=604800&departureLat=0&departureLng=0" \
   --expectResponseCode=200 \
-  --auth="$API_TOKEN"
+  --expectNonEmpty \
+  --auth="$API_TOKEN" \
+  -v
 
 echo "TestDriverJourneys/Departure_radius_1"
 go run main.go test \
@@ -113,6 +115,118 @@ echo "TestDriverJourneys/Count_4_-_count_>_n_driver_journeys"
 go run main.go test \
   --method=GET \
   --url="$SERVER/driver_journeys?arrivalLat=0&arrivalLng=0&count=1&departureDate=9676800&departureLat=0&departureLng=0" \
+  --expectResponseCode=200 \
+  --auth="$API_TOKEN"
+
+echo "TestPassengerJourneys/No_data"
+go run main.go test \
+  --method=GET \
+  --url="$SERVER/passenger_journeys?arrivalLat=0&arrivalLng=0&departureDate=10281600&departureLat=0&departureLng=0" \
+  --expectResponseCode=200 \
+  --auth="$API_TOKEN"
+
+echo "TestPassengerJourneys/Departure_radius_0"
+go run main.go test \
+  --method=GET \
+  --url="$SERVER/passenger_journeys?arrivalLat=0&arrivalLng=0&departureDate=10886400&departureLat=46.160454&departureLng=-1.2219607&departureRadius=1" \
+  --expectResponseCode=200 \
+  --auth="$API_TOKEN"
+
+echo "TestPassengerJourneys/Departure_radius_1"
+go run main.go test \
+  --method=GET \
+  --url="$SERVER/passenger_journeys?arrivalLat=0&arrivalLng=0&departureDate=11491200&departureLat=46.160454&departureLng=-1.2219607&departureRadius=1" \
+  --expectResponseCode=200 \
+  --auth="$API_TOKEN"
+
+echo "TestPassengerJourneys/Departure_radius_2"
+go run main.go test \
+  --method=GET \
+  --url="$SERVER/passenger_journeys?arrivalLat=0&arrivalLng=0&departureDate=12096000&departureLat=46.160454&departureLng=-1.2219607&departureRadius=2" \
+  --expectResponseCode=200 \
+  --auth="$API_TOKEN"
+
+echo "TestPassengerJourneys/Departure_radius_3"
+go run main.go test \
+  --method=GET \
+  --url="$SERVER/passenger_journeys?arrivalLat=0&arrivalLng=0&departureDate=12700800&departureLat=46.160454&departureLng=-1.2219607&departureRadius=1" \
+  --expectResponseCode=200 \
+  --auth="$API_TOKEN"
+
+echo "TestPassengerJourneys/Arrival_radius_1"
+go run main.go test \
+  --method=GET \
+  --url="$SERVER/passenger_journeys?arrivalLat=46.160454&arrivalLng=-1.2219607&arrivalRadius=1&departureDate=13305600&departureLat=0&departureLng=0" \
+  --expectResponseCode=200 \
+  --auth="$API_TOKEN"
+
+echo "TestPassengerJourneys/Arrival_radius_2"
+go run main.go test \
+  --method=GET \
+  --url="$SERVER/passenger_journeys?arrivalLat=46.160454&arrivalLng=-1.2219607&arrivalRadius=2&departureDate=13910400&departureLat=0&departureLng=0" \
+  --expectResponseCode=200 \
+  --auth="$API_TOKEN"
+
+echo "TestPassengerJourneys/Arrival_radius_3"
+go run main.go test \
+  --method=GET \
+  --url="$SERVER/passenger_journeys?arrivalLat=46.160454&arrivalLng=-1.2219607&arrivalRadius=1&departureDate=14515200&departureLat=0&departureLng=0" \
+  --expectResponseCode=200 \
+  --auth="$API_TOKEN"
+
+echo "TestPassengerJourneys/Arrival_radius_4"
+go run main.go test \
+  --method=GET \
+  --url="$SERVER/passenger_journeys?arrivalLat=46.160454&arrivalLng=-1.2219607&arrivalRadius=1&departureDate=15120000&departureLat=0&departureLng=0" \
+  --expectResponseCode=200 \
+  --auth="$API_TOKEN"
+
+echo "TestPassengerJourneys/TimeDelta_1"
+go run main.go test \
+  --method=GET \
+  --url="$SERVER/passenger_journeys?arrivalLat=0&arrivalLng=0&departureDate=15724800&departureLat=0&departureLng=0&timeDelta=10" \
+  --expectResponseCode=200 \
+  --auth="$API_TOKEN"
+
+echo "TestPassengerJourneys/TimeDelta_2"
+go run main.go test \
+  --method=GET \
+  --url="$SERVER/passenger_journeys?arrivalLat=0&arrivalLng=0&departureDate=16329600&departureLat=0&departureLng=0&timeDelta=10" \
+  --expectResponseCode=200 \
+  --auth="$API_TOKEN"
+
+echo "TestPassengerJourneys/TimeDelta_3"
+go run main.go test \
+  --method=GET \
+  --url="$SERVER/passenger_journeys?arrivalLat=0&arrivalLng=0&departureDate=16934400&departureLat=0&departureLng=0&timeDelta=20" \
+  --expectResponseCode=200 \
+  --auth="$API_TOKEN"
+
+echo "TestPassengerJourneys/Count_1"
+go run main.go test \
+  --method=GET \
+  --url="$SERVER/passenger_journeys?arrivalLat=0&arrivalLng=0&count=1&departureDate=17539200&departureLat=0&departureLng=0" \
+  --expectResponseCode=200 \
+  --auth="$API_TOKEN"
+
+echo "TestPassengerJourneys/Count_2"
+go run main.go test \
+  --method=GET \
+  --url="$SERVER/passenger_journeys?arrivalLat=0&arrivalLng=0&count=0&departureDate=18144000&departureLat=0&departureLng=0" \
+  --expectResponseCode=200 \
+  --auth="$API_TOKEN"
+
+echo "TestPassengerJourneys/Count_3"
+go run main.go test \
+  --method=GET \
+  --url="$SERVER/passenger_journeys?arrivalLat=0&arrivalLng=0&count=2&departureDate=18748800&departureLat=0&departureLng=0" \
+  --expectResponseCode=200 \
+  --auth="$API_TOKEN"
+
+echo "TestPassengerJourneys/Count_4_-_count_>_n_passenger_journeys"
+go run main.go test \
+  --method=GET \
+  --url="$SERVER/passenger_journeys?arrivalLat=0&arrivalLng=0&count=1&departureDate=19353600&departureLat=0&departureLng=0" \
   --expectResponseCode=200 \
   --auth="$API_TOKEN"
 

--- a/cmd/test/commands/testCommands.gen.sh
+++ b/cmd/test/commands/testCommands.gen.sh
@@ -4,21 +4,131 @@
 export SERVER="http://localhost:1323"
 export API_TOKEN=""
 
+echo "TestDriverJourneys/No_data"
+go run main.go test \
+  --method=GET \
+  --url="$SERVER/driver_journeys?arrivalLat=0&arrivalLng=0&departureDate=604800&departureLat=0&departureLng=0" \
+  --expectResponseCode=200 \
+  --auth="$API_TOKEN"
+
+echo "TestDriverJourneys/Departure_radius_1"
+go run main.go test \
+  --method=GET \
+  --url="$SERVER/driver_journeys?arrivalLat=0&arrivalLng=0&departureDate=1209600&departureLat=46.160454&departureLng=-1.2219607&departureRadius=1" \
+  --expectResponseCode=200 \
+  --auth="$API_TOKEN"
+
+echo "TestDriverJourneys/Departure_radius_2"
+go run main.go test \
+  --method=GET \
+  --url="$SERVER/driver_journeys?arrivalLat=0&arrivalLng=0&departureDate=1814400&departureLat=46.160454&departureLng=-1.2219607&departureRadius=2" \
+  --expectResponseCode=200 \
+  --auth="$API_TOKEN"
+
+echo "TestDriverJourneys/Departure_radius_3"
+go run main.go test \
+  --method=GET \
+  --url="$SERVER/driver_journeys?arrivalLat=0&arrivalLng=0&departureDate=2419200&departureLat=46.160454&departureLng=-1.2219607&departureRadius=1" \
+  --expectResponseCode=200 \
+  --auth="$API_TOKEN"
+
+echo "TestDriverJourneys/Departure_radius_3#01"
+go run main.go test \
+  --method=GET \
+  --url="$SERVER/driver_journeys?arrivalLat=0&arrivalLng=0&departureDate=3024000&departureLat=46.160454&departureLng=-1.2219607&departureRadius=1" \
+  --expectResponseCode=200 \
+  --auth="$API_TOKEN"
+
+echo "TestDriverJourneys/Arrival_radius_1"
+go run main.go test \
+  --method=GET \
+  --url="$SERVER/driver_journeys?arrivalLat=46.160454&arrivalLng=-1.2219607&arrivalRadius=1&departureDate=3628800&departureLat=0&departureLng=0" \
+  --expectResponseCode=200 \
+  --auth="$API_TOKEN"
+
+echo "TestDriverJourneys/Arrival_radius_2"
+go run main.go test \
+  --method=GET \
+  --url="$SERVER/driver_journeys?arrivalLat=46.160454&arrivalLng=-1.2219607&arrivalRadius=2&departureDate=4233600&departureLat=0&departureLng=0" \
+  --expectResponseCode=200 \
+  --auth="$API_TOKEN"
+
+echo "TestDriverJourneys/Arrival_radius_3"
+go run main.go test \
+  --method=GET \
+  --url="$SERVER/driver_journeys?arrivalLat=46.160454&arrivalLng=-1.2219607&arrivalRadius=1&departureDate=4838400&departureLat=0&departureLng=0" \
+  --expectResponseCode=200 \
+  --auth="$API_TOKEN"
+
+echo "TestDriverJourneys/Arrival_radius_4"
+go run main.go test \
+  --method=GET \
+  --url="$SERVER/driver_journeys?arrivalLat=46.160454&arrivalLng=-1.2219607&arrivalRadius=1&departureDate=5443200&departureLat=0&departureLng=0" \
+  --expectResponseCode=200 \
+  --auth="$API_TOKEN"
+
+echo "TestDriverJourneys/TimeDelta_1"
+go run main.go test \
+  --method=GET \
+  --url="$SERVER/driver_journeys?arrivalLat=0&arrivalLng=0&departureDate=6048000&departureLat=0&departureLng=0&timeDelta=10" \
+  --expectResponseCode=200 \
+  --auth="$API_TOKEN"
+
+echo "TestDriverJourneys/TimeDelta_2"
+go run main.go test \
+  --method=GET \
+  --url="$SERVER/driver_journeys?arrivalLat=0&arrivalLng=0&departureDate=6652800&departureLat=0&departureLng=0&timeDelta=10" \
+  --expectResponseCode=200 \
+  --auth="$API_TOKEN"
+
+echo "TestDriverJourneys/TimeDelta_3"
+go run main.go test \
+  --method=GET \
+  --url="$SERVER/driver_journeys?arrivalLat=0&arrivalLng=0&departureDate=7257600&departureLat=0&departureLng=0&timeDelta=20" \
+  --expectResponseCode=200 \
+  --auth="$API_TOKEN"
+
+echo "TestDriverJourneys/Count_1"
+go run main.go test \
+  --method=GET \
+  --url="$SERVER/driver_journeys?arrivalLat=0&arrivalLng=0&count=1&departureDate=7862400&departureLat=0&departureLng=0" \
+  --expectResponseCode=200 \
+  --auth="$API_TOKEN"
+
+echo "TestDriverJourneys/Count_2"
+go run main.go test \
+  --method=GET \
+  --url="$SERVER/driver_journeys?arrivalLat=0&arrivalLng=0&count=0&departureDate=8467200&departureLat=0&departureLng=0" \
+  --expectResponseCode=200 \
+  --auth="$API_TOKEN"
+
+echo "TestDriverJourneys/Count_3"
+go run main.go test \
+  --method=GET \
+  --url="$SERVER/driver_journeys?arrivalLat=0&arrivalLng=0&count=2&departureDate=9072000&departureLat=0&departureLng=0" \
+  --expectResponseCode=200 \
+  --auth="$API_TOKEN"
+
+echo "TestDriverJourneys/Count_4_-_count_>_n_driver_journeys"
+go run main.go test \
+  --method=GET \
+  --url="$SERVER/driver_journeys?arrivalLat=0&arrivalLng=0&count=1&departureDate=9676800&departureLat=0&departureLng=0" \
+  --expectResponseCode=200 \
+  --auth="$API_TOKEN"
+
 echo "TestGetBookings/getting_a_non-existing_booking_returns_code_404"
 go run main.go test \
   --method=GET \
   --url="$SERVER/bookings/52fdfc07-2182-654f-163f-5f0f9a621d72" \
   --expectResponseCode=404 \
-  --auth="$API_TOKEN" \
-  -v
+  --auth="$API_TOKEN"
 
 echo "TestGetBookings/getting_an_existing_booking_returns_it_with_code_200_#1"
 go run main.go test \
   --method=GET \
   --url="$SERVER/bookings/2f8282cb-e2f9-696f-3144-c0aa4ced56db" \
   --expectResponseCode=200 \
-  --auth="$API_TOKEN" \
-  -v
+  --auth="$API_TOKEN"
 
 echo "TestGetBookings/getting_an_existing_booking_returns_it_with_code_200_#2"
 go run main.go test \

--- a/cmd/test/commands/testCommands.gen.sh
+++ b/cmd/test/commands/testCommands.gen.sh
@@ -9,23 +9,23 @@ go run main.go test \
   --method=GET \
   --url="$SERVER/driver_journeys?arrivalLat=0&arrivalLng=0&departureDate=604800&departureLat=0&departureLng=0" \
   --expectResponseCode=200 \
-  --expectNonEmpty \
-  --auth="$API_TOKEN" \
-  -v
+  --auth="$API_TOKEN"
 
 echo "TestDriverJourneys/Departure_radius_1"
 go run main.go test \
   --method=GET \
   --url="$SERVER/driver_journeys?arrivalLat=0&arrivalLng=0&departureDate=1209600&departureLat=46.160454&departureLng=-1.2219607&departureRadius=1" \
   --expectResponseCode=200 \
-  --auth="$API_TOKEN"
+  --auth="$API_TOKEN" \
+  --expectNonEmpty
 
 echo "TestDriverJourneys/Departure_radius_2"
 go run main.go test \
   --method=GET \
   --url="$SERVER/driver_journeys?arrivalLat=0&arrivalLng=0&departureDate=1814400&departureLat=46.160454&departureLng=-1.2219607&departureRadius=2" \
   --expectResponseCode=200 \
-  --auth="$API_TOKEN"
+  --auth="$API_TOKEN" \
+  --expectNonEmpty
 
 echo "TestDriverJourneys/Departure_radius_3"
 go run main.go test \
@@ -39,21 +39,24 @@ go run main.go test \
   --method=GET \
   --url="$SERVER/driver_journeys?arrivalLat=0&arrivalLng=0&departureDate=3024000&departureLat=46.160454&departureLng=-1.2219607&departureRadius=1" \
   --expectResponseCode=200 \
-  --auth="$API_TOKEN"
+  --auth="$API_TOKEN" \
+  --expectNonEmpty
 
 echo "TestDriverJourneys/Arrival_radius_1"
 go run main.go test \
   --method=GET \
   --url="$SERVER/driver_journeys?arrivalLat=46.160454&arrivalLng=-1.2219607&arrivalRadius=1&departureDate=3628800&departureLat=0&departureLng=0" \
   --expectResponseCode=200 \
-  --auth="$API_TOKEN"
+  --auth="$API_TOKEN" \
+  --expectNonEmpty
 
 echo "TestDriverJourneys/Arrival_radius_2"
 go run main.go test \
   --method=GET \
   --url="$SERVER/driver_journeys?arrivalLat=46.160454&arrivalLng=-1.2219607&arrivalRadius=2&departureDate=4233600&departureLat=0&departureLng=0" \
   --expectResponseCode=200 \
-  --auth="$API_TOKEN"
+  --auth="$API_TOKEN" \
+  --expectNonEmpty
 
 echo "TestDriverJourneys/Arrival_radius_3"
 go run main.go test \
@@ -67,14 +70,16 @@ go run main.go test \
   --method=GET \
   --url="$SERVER/driver_journeys?arrivalLat=46.160454&arrivalLng=-1.2219607&arrivalRadius=1&departureDate=5443200&departureLat=0&departureLng=0" \
   --expectResponseCode=200 \
-  --auth="$API_TOKEN"
+  --auth="$API_TOKEN" \
+  --expectNonEmpty
 
 echo "TestDriverJourneys/TimeDelta_1"
 go run main.go test \
   --method=GET \
   --url="$SERVER/driver_journeys?arrivalLat=0&arrivalLng=0&departureDate=6048000&departureLat=0&departureLng=0&timeDelta=10" \
   --expectResponseCode=200 \
-  --auth="$API_TOKEN"
+  --auth="$API_TOKEN" \
+  --expectNonEmpty
 
 echo "TestDriverJourneys/TimeDelta_2"
 go run main.go test \
@@ -88,14 +93,16 @@ go run main.go test \
   --method=GET \
   --url="$SERVER/driver_journeys?arrivalLat=0&arrivalLng=0&departureDate=7257600&departureLat=0&departureLng=0&timeDelta=20" \
   --expectResponseCode=200 \
-  --auth="$API_TOKEN"
+  --auth="$API_TOKEN" \
+  --expectNonEmpty
 
 echo "TestDriverJourneys/Count_1"
 go run main.go test \
   --method=GET \
   --url="$SERVER/driver_journeys?arrivalLat=0&arrivalLng=0&count=1&departureDate=7862400&departureLat=0&departureLng=0" \
   --expectResponseCode=200 \
-  --auth="$API_TOKEN"
+  --auth="$API_TOKEN" \
+  --expectNonEmpty
 
 echo "TestDriverJourneys/Count_2"
 go run main.go test \
@@ -109,7 +116,8 @@ go run main.go test \
   --method=GET \
   --url="$SERVER/driver_journeys?arrivalLat=0&arrivalLng=0&count=2&departureDate=9072000&departureLat=0&departureLng=0" \
   --expectResponseCode=200 \
-  --auth="$API_TOKEN"
+  --auth="$API_TOKEN" \
+  --expectNonEmpty
 
 echo "TestDriverJourneys/Count_4_-_count_>_n_driver_journeys"
 go run main.go test \
@@ -130,21 +138,24 @@ go run main.go test \
   --method=GET \
   --url="$SERVER/passenger_journeys?arrivalLat=0&arrivalLng=0&departureDate=10886400&departureLat=46.160454&departureLng=-1.2219607&departureRadius=1" \
   --expectResponseCode=200 \
-  --auth="$API_TOKEN"
+  --auth="$API_TOKEN" \
+  --expectNonEmpty
 
 echo "TestPassengerJourneys/Departure_radius_1"
 go run main.go test \
   --method=GET \
   --url="$SERVER/passenger_journeys?arrivalLat=0&arrivalLng=0&departureDate=11491200&departureLat=46.160454&departureLng=-1.2219607&departureRadius=1" \
   --expectResponseCode=200 \
-  --auth="$API_TOKEN"
+  --auth="$API_TOKEN" \
+  --expectNonEmpty
 
 echo "TestPassengerJourneys/Departure_radius_2"
 go run main.go test \
   --method=GET \
   --url="$SERVER/passenger_journeys?arrivalLat=0&arrivalLng=0&departureDate=12096000&departureLat=46.160454&departureLng=-1.2219607&departureRadius=2" \
   --expectResponseCode=200 \
-  --auth="$API_TOKEN"
+  --auth="$API_TOKEN" \
+  --expectNonEmpty
 
 echo "TestPassengerJourneys/Departure_radius_3"
 go run main.go test \
@@ -158,14 +169,16 @@ go run main.go test \
   --method=GET \
   --url="$SERVER/passenger_journeys?arrivalLat=46.160454&arrivalLng=-1.2219607&arrivalRadius=1&departureDate=13305600&departureLat=0&departureLng=0" \
   --expectResponseCode=200 \
-  --auth="$API_TOKEN"
+  --auth="$API_TOKEN" \
+  --expectNonEmpty
 
 echo "TestPassengerJourneys/Arrival_radius_2"
 go run main.go test \
   --method=GET \
   --url="$SERVER/passenger_journeys?arrivalLat=46.160454&arrivalLng=-1.2219607&arrivalRadius=2&departureDate=13910400&departureLat=0&departureLng=0" \
   --expectResponseCode=200 \
-  --auth="$API_TOKEN"
+  --auth="$API_TOKEN" \
+  --expectNonEmpty
 
 echo "TestPassengerJourneys/Arrival_radius_3"
 go run main.go test \
@@ -179,14 +192,16 @@ go run main.go test \
   --method=GET \
   --url="$SERVER/passenger_journeys?arrivalLat=46.160454&arrivalLng=-1.2219607&arrivalRadius=1&departureDate=15120000&departureLat=0&departureLng=0" \
   --expectResponseCode=200 \
-  --auth="$API_TOKEN"
+  --auth="$API_TOKEN" \
+  --expectNonEmpty
 
 echo "TestPassengerJourneys/TimeDelta_1"
 go run main.go test \
   --method=GET \
   --url="$SERVER/passenger_journeys?arrivalLat=0&arrivalLng=0&departureDate=15724800&departureLat=0&departureLng=0&timeDelta=10" \
   --expectResponseCode=200 \
-  --auth="$API_TOKEN"
+  --auth="$API_TOKEN" \
+  --expectNonEmpty
 
 echo "TestPassengerJourneys/TimeDelta_2"
 go run main.go test \
@@ -200,14 +215,16 @@ go run main.go test \
   --method=GET \
   --url="$SERVER/passenger_journeys?arrivalLat=0&arrivalLng=0&departureDate=16934400&departureLat=0&departureLng=0&timeDelta=20" \
   --expectResponseCode=200 \
-  --auth="$API_TOKEN"
+  --auth="$API_TOKEN" \
+  --expectNonEmpty
 
 echo "TestPassengerJourneys/Count_1"
 go run main.go test \
   --method=GET \
   --url="$SERVER/passenger_journeys?arrivalLat=0&arrivalLng=0&count=1&departureDate=17539200&departureLat=0&departureLng=0" \
   --expectResponseCode=200 \
-  --auth="$API_TOKEN"
+  --auth="$API_TOKEN" \
+  --expectNonEmpty
 
 echo "TestPassengerJourneys/Count_2"
 go run main.go test \
@@ -221,7 +238,8 @@ go run main.go test \
   --method=GET \
   --url="$SERVER/passenger_journeys?arrivalLat=0&arrivalLng=0&count=2&departureDate=18748800&departureLat=0&departureLng=0" \
   --expectResponseCode=200 \
-  --auth="$API_TOKEN"
+  --auth="$API_TOKEN" \
+  --expectNonEmpty
 
 echo "TestPassengerJourneys/Count_4_-_count_>_n_passenger_journeys"
 go run main.go test \
@@ -242,14 +260,16 @@ go run main.go test \
   --method=GET \
   --url="$SERVER/bookings/2f8282cb-e2f9-696f-3144-c0aa4ced56db" \
   --expectResponseCode=200 \
-  --auth="$API_TOKEN"
+  --auth="$API_TOKEN" \
+  --expectNonEmpty
 
 echo "TestGetBookings/getting_an_existing_booking_returns_it_with_code_200_#2"
 go run main.go test \
   --method=GET \
   --url="$SERVER/bookings/e2807d9c-1dce-26af-00ca-81d4fe11c23e" \
   --expectResponseCode=200 \
-  --auth="$API_TOKEN"
+  --auth="$API_TOKEN" \
+  --expectNonEmpty
 
 echo "TestPostBookings/Posting_a_new_booking_succeeds_with_code_201"
 go run main.go test \
@@ -264,7 +284,8 @@ go run main.go test \
   --method=GET \
   --url="$SERVER/bookings/83472eda-6eb4-7590-6aee-b7f09e757ba9" \
   --expectResponseCode=200 \
-  --auth="$API_TOKEN"
+  --auth="$API_TOKEN" \
+  --expectNonEmpty
 
 echo "TestPostBookings/Posting_a_booking_with_colliding_ID_fails_with_code_400"
 go run main.go test \
@@ -279,7 +300,8 @@ go run main.go test \
   --method=GET \
   --url="$SERVER/bookings/590c1440-9888-b5b0-7d51-a817ee07c3f2" \
   --expectResponseCode=200 \
-  --auth="$API_TOKEN"
+  --auth="$API_TOKEN" \
+  --expectNonEmpty
 
 echo "TestPatchBookings/patching_VALIDATED_over_WAITING_CONFIRMATION_succeeds"
 go run main.go test \


### PR DESCRIPTION
This PR improve test generations, example test commands for GET /driver_journeys and GET /passenger_journeys are now generated as well. 

To isolate (as much as possible) the tests without isolating the data, each test data is set to a different week. In this way, as soon as the query filtering by date is working well, each command is rightly associated with its data.

This is as much as can be done if we do not want to load the data for each test separately. 